### PR TITLE
Events

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockAzalea.java
+++ b/src/main/java/cn/nukkit/block/BlockAzalea.java
@@ -183,13 +183,13 @@ public class BlockAzalea extends BlockFlowable implements BlockFlowerPot.FlowerP
 
         ListChunkManager chunkManager = new ListChunkManager(this.level);
         boolean success = generator.generate(chunkManager, new NukkitRandom(), vector3);
-        StructureGrowEvent ev = new StructureGrowEvent(this, chunkManager.getBlocks());
-        this.level.getServer().getPluginManager().callEvent(ev);
-        if (ev.isCancelled() || !success) {
+        StructureGrowEvent event = new StructureGrowEvent(this, chunkManager.getBlocks());
+        event.call();
+        if (event.isCancelled() || !success) {
             return;
         }
 
-        for (Block block : ev.getBlockList()) {
+        for (Block block : event.getBlockList()) {
             this.level.setBlock(block, block);
         }
         this.level.setBlock(this, Block.get(LOG));

--- a/src/main/java/cn/nukkit/block/BlockBamboo.java
+++ b/src/main/java/cn/nukkit/block/BlockBamboo.java
@@ -103,7 +103,7 @@ public class BlockBamboo extends BlockTransparentMeta implements BlockFlowerPot.
             newState.setLeafSize(LEAF_SIZE_SMALL);
         }
         BlockGrowEvent blockGrowEvent = new BlockGrowEvent(up, newState);
-        level.getServer().getPluginManager().callEvent(blockGrowEvent);
+        blockGrowEvent.call();
         if (!blockGrowEvent.isCancelled()) {
             Block newState1 = blockGrowEvent.getNewState();
             newState1.x = x;

--- a/src/main/java/cn/nukkit/block/BlockBambooSapling.java
+++ b/src/main/java/cn/nukkit/block/BlockBambooSapling.java
@@ -72,7 +72,7 @@ public class BlockBambooSapling extends BlockFlowable {
                 BlockBamboo newState = new BlockBamboo();
                 newState.setLeafSize(BlockBamboo.LEAF_SIZE_SMALL);
                 BlockGrowEvent blockGrowEvent = new BlockGrowEvent(up, newState);
-                level.getServer().getPluginManager().callEvent(blockGrowEvent);
+                blockGrowEvent.call();
                 if (!blockGrowEvent.isCancelled()) {
                     Block newState1 = blockGrowEvent.getNewState();
                     newState1.y = up.y;

--- a/src/main/java/cn/nukkit/block/BlockBell.java
+++ b/src/main/java/cn/nukkit/block/BlockBell.java
@@ -271,7 +271,7 @@ public class BlockBell extends BlockTransparentMeta
         }
 
         BellRingEvent event = new BellRingEvent(this, cause, causeEntity);
-        this.level.getServer().getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) {
             return false;
         }

--- a/src/main/java/cn/nukkit/block/BlockBigDripleaf.java
+++ b/src/main/java/cn/nukkit/block/BlockBigDripleaf.java
@@ -2,7 +2,6 @@ package cn.nukkit.block;
 
 import static cn.nukkit.block.BlockBigDripleaf.Tilt.*;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
@@ -89,7 +88,7 @@ public class BlockBigDripleaf extends BlockFlowable implements Faceable {
 
     public boolean setTilt(Tilt tilt) {
         BigDripleafTiltChangeEvent event = new BigDripleafTiltChangeEvent(this, this.getTilt(), tilt);
-        Server.getInstance().getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) return false;
         this.setPropertyValue(TILT, tilt);
         return true;

--- a/src/main/java/cn/nukkit/block/BlockButton.java
+++ b/src/main/java/cn/nukkit/block/BlockButton.java
@@ -114,7 +114,7 @@ public abstract class BlockButton extends BlockFlowable implements RedstoneCompo
                 LevelSoundEventPacket.SOUND_POWER_ON,
                 GlobalBlockPalette.getOrCreateRuntimeId(this.getId(), this.getDamage()));
         if (this.level.getServer().isRedstoneEnabled()) {
-            this.level.getServer().getPluginManager().callEvent(new BlockRedstoneEvent(this, 0, 15));
+            new BlockRedstoneEvent(this, 0, 15).call();
 
             updateAroundRedstone();
             RedstoneComponent.updateAroundRedstone(getSide(getFacing().getOpposite()), getFacing());
@@ -144,7 +144,7 @@ public abstract class BlockButton extends BlockFlowable implements RedstoneCompo
                         GlobalBlockPalette.getOrCreateRuntimeId(this.getId(), this.getDamage()));
 
                 if (this.level.getServer().isRedstoneEnabled()) {
-                    this.level.getServer().getPluginManager().callEvent(new BlockRedstoneEvent(this, 15, 0));
+                    new BlockRedstoneEvent(this, 15, 0).call();
 
                     updateAroundRedstone();
                     RedstoneComponent.updateAroundRedstone(getSide(getFacing().getOpposite()), getFacing());
@@ -213,7 +213,7 @@ public abstract class BlockButton extends BlockFlowable implements RedstoneCompo
     @Override
     public boolean onBreak(Item item) {
         if (isActivated()) {
-            this.level.getServer().getPluginManager().callEvent(new BlockRedstoneEvent(this, 15, 0));
+            new BlockRedstoneEvent(this, 15, 0).call();
         }
 
         return super.onBreak(item);

--- a/src/main/java/cn/nukkit/block/BlockCactus.java
+++ b/src/main/java/cn/nukkit/block/BlockCactus.java
@@ -1,6 +1,5 @@
 package cn.nukkit.block;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockproperty.BlockProperties;
@@ -129,7 +128,7 @@ public class BlockCactus extends BlockTransparentMeta implements BlockFlowerPot.
                         Block b = this.getLevel().getBlock(new Vector3(this.x, this.y + y, this.z));
                         if (b.getId() == AIR) {
                             BlockGrowEvent event = new BlockGrowEvent(b, Block.get(BlockID.CACTUS));
-                            Server.getInstance().getPluginManager().callEvent(event);
+                            event.call();
                             if (!event.isCancelled()) {
                                 this.getLevel().setBlock(b, event.getNewState(), true);
                             }

--- a/src/main/java/cn/nukkit/block/BlockCampfire.java
+++ b/src/main/java/cn/nukkit/block/BlockCampfire.java
@@ -2,7 +2,6 @@ package cn.nukkit.block;
 
 import static cn.nukkit.blockproperty.CommonBlockProperties.DIRECTION;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockentity.BlockEntity;
@@ -196,10 +195,10 @@ public class BlockCampfire extends BlockTransparentMeta implements Faceable, Blo
             return;
         }
 
-        EntityCombustByBlockEvent ev = new EntityCombustByBlockEvent(this, entity, 8);
-        Server.getInstance().getPluginManager().callEvent(ev);
-        if (!ev.isCancelled() && entity.isAlive()) {
-            entity.setOnFire(ev.getDuration());
+        EntityCombustByBlockEvent event = new EntityCombustByBlockEvent(this, entity, 8);
+        event.call();
+        if (!event.isCancelled() && entity.isAlive()) {
+            entity.setOnFire(event.getDuration());
         }
     }
 

--- a/src/main/java/cn/nukkit/block/BlockCauldron.java
+++ b/src/main/java/cn/nukkit/block/BlockCauldron.java
@@ -1,6 +1,5 @@
 package cn.nukkit.block;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitDifference;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.PowerNukkitXOnly;
@@ -185,16 +184,16 @@ public class BlockCauldron extends BlockSolidMeta implements BlockEntityHolder<B
                         break;
                     }
 
-                    PlayerBucketFillEvent ev = new PlayerBucketFillEvent(
+                    PlayerBucketFillEvent event = new PlayerBucketFillEvent(
                             player,
                             this,
                             null,
                             this,
                             item,
                             MinecraftItemID.WATER_BUCKET.get(1, bucket.getCompoundTag()));
-                    this.level.getServer().getPluginManager().callEvent(ev);
-                    if (!ev.isCancelled()) {
-                        replaceBucket(bucket, player, ev.getItem());
+                    event.call();
+                    if (!event.isCancelled()) {
+                        replaceBucket(bucket, player, event.getItem());
                         this.setFillLevel(FILL_LEVEL.getMinValue(), player); // empty
                         this.level.setBlock(this, this, true);
                         cauldron.clearCustomColor();
@@ -208,12 +207,12 @@ public class BlockCauldron extends BlockSolidMeta implements BlockEntityHolder<B
                         break;
                     }
 
-                    PlayerBucketEmptyEvent ev = new PlayerBucketEmptyEvent(
+                    PlayerBucketEmptyEvent event = new PlayerBucketEmptyEvent(
                             player, this, null, this, item, MinecraftItemID.BUCKET.get(1, bucket.getCompoundTag()));
-                    this.level.getServer().getPluginManager().callEvent(ev);
-                    if (!ev.isCancelled()) {
+                    event.call();
+                    if (!event.isCancelled()) {
                         if (player.isSurvival() || player.isAdventure()) {
-                            replaceBucket(bucket, player, ev.getItem());
+                            replaceBucket(bucket, player, event.getItem());
                         }
                         if (cauldron.hasPotion()) { // if has potion
                             clearWithFizz(cauldron, player);
@@ -478,16 +477,16 @@ public class BlockCauldron extends BlockSolidMeta implements BlockEntityHolder<B
                         break;
                     }
 
-                    PlayerBucketFillEvent ev = new PlayerBucketFillEvent(
+                    PlayerBucketFillEvent event = new PlayerBucketFillEvent(
                             player,
                             this,
                             null,
                             this,
                             item,
                             MinecraftItemID.LAVA_BUCKET.get(1, bucket.getCompoundTag()));
-                    this.level.getServer().getPluginManager().callEvent(ev);
-                    if (!ev.isCancelled()) {
-                        replaceBucket(bucket, player, ev.getItem());
+                    event.call();
+                    if (!event.isCancelled()) {
+                        replaceBucket(bucket, player, event.getItem());
                         this.setFillLevel(FILL_LEVEL.getMinValue(), player); // empty
                         this.level.setBlock(this, new BlockCauldron(0), true);
                         cauldron.clearCustomColor();
@@ -498,11 +497,11 @@ public class BlockCauldron extends BlockSolidMeta implements BlockEntityHolder<B
                         break;
                     }
 
-                    PlayerBucketEmptyEvent ev = new PlayerBucketEmptyEvent(
+                    PlayerBucketEmptyEvent event = new PlayerBucketEmptyEvent(
                             player, this, null, this, item, MinecraftItemID.BUCKET.get(1, bucket.getCompoundTag()));
-                    this.level.getServer().getPluginManager().callEvent(ev);
-                    if (!ev.isCancelled()) {
-                        replaceBucket(bucket, player, ev.getItem());
+                    event.call();
+                    if (!event.isCancelled()) {
+                        replaceBucket(bucket, player, event.getItem());
 
                         if (cauldron.hasPotion()) { // if has potion
                             clearWithFizz(cauldron);
@@ -689,12 +688,12 @@ public class BlockCauldron extends BlockSolidMeta implements BlockEntityHolder<B
 
     @Override
     public void onEntityCollide(Entity entity) {
-        EntityCombustByBlockEvent ev = new EntityCombustByBlockEvent(this, entity, 15);
-        Server.getInstance().getPluginManager().callEvent(ev);
-        if (!ev.isCancelled()) {
+        EntityCombustByBlockEvent event = new EntityCombustByBlockEvent(this, entity, 15);
+        event.call();
+        if (!event.isCancelled()) {
             // Making sure the entity is actually alive and not invulnerable.
             if (getCauldronLiquid() == CauldronLiquid.LAVA && entity.isAlive() && entity.noDamageTicks == 0) {
-                entity.setOnFire(ev.getDuration());
+                entity.setOnFire(event.getDuration());
                 if (!entity.hasEffect(Effect.FIRE_RESISTANCE)) {
                     entity.attack(new EntityDamageByBlockEvent(this, entity, EntityDamageEvent.DamageCause.LAVA, 4));
                 }

--- a/src/main/java/cn/nukkit/block/BlockCauldronLava.java
+++ b/src/main/java/cn/nukkit/block/BlockCauldronLava.java
@@ -1,6 +1,5 @@
 package cn.nukkit.block;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.DeprecationDetails;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.blockentity.BlockEntity;
@@ -69,13 +68,13 @@ public class BlockCauldronLava extends BlockCauldron {
     @Override
     public void onEntityCollide(Entity entity) {
         // Always setting the duration to 15 seconds? TODO
-        EntityCombustByBlockEvent ev = new EntityCombustByBlockEvent(this, entity, 15);
-        Server.getInstance().getPluginManager().callEvent(ev);
-        if (!ev.isCancelled()
+        EntityCombustByBlockEvent event = new EntityCombustByBlockEvent(this, entity, 15);
+        event.call();
+        if (!event.isCancelled()
                 // Making sure the entity is actually alive and not invulnerable.
                 && entity.isAlive()
                 && entity.noDamageTicks == 0) {
-            entity.setOnFire(ev.getDuration());
+            entity.setOnFire(event.getDuration());
         }
 
         if (!entity.hasEffect(Effect.FIRE_RESISTANCE)) {
@@ -111,7 +110,7 @@ public class BlockCauldronLava extends BlockCauldron {
                             this,
                             item,
                             MinecraftItemID.LAVA_BUCKET.get(1, bucket.getCompoundTag()));
-                    this.level.getServer().getPluginManager().callEvent(ev);
+                    ev.call();
                     if (!ev.isCancelled()) {
                         replaceBucket(bucket, player, ev.getItem());
                         this.setFillLevel(FILL_LEVEL.getMinValue(), player); // empty
@@ -124,11 +123,11 @@ public class BlockCauldronLava extends BlockCauldron {
                         break;
                     }
 
-                    PlayerBucketEmptyEvent ev = new PlayerBucketEmptyEvent(
+                    PlayerBucketEmptyEvent event = new PlayerBucketEmptyEvent(
                             player, this, null, this, item, MinecraftItemID.BUCKET.get(1, bucket.getCompoundTag()));
-                    this.level.getServer().getPluginManager().callEvent(ev);
-                    if (!ev.isCancelled()) {
-                        replaceBucket(bucket, player, ev.getItem());
+                    event.call();
+                    if (!event.isCancelled()) {
+                        replaceBucket(bucket, player, event.getItem());
 
                         if (cauldron.hasPotion()) { // if has potion
                             clearWithFizz(cauldron);

--- a/src/main/java/cn/nukkit/block/BlockCaveVines.java
+++ b/src/main/java/cn/nukkit/block/BlockCaveVines.java
@@ -1,6 +1,5 @@
 package cn.nukkit.block;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
@@ -80,10 +79,10 @@ public class BlockCaveVines extends BlockTransparentMeta {
                 if (growth + 4 < getMaxGrowth()) {
                     BlockCaveVines block = (BlockCaveVines) this.clone();
                     block.setGrowth(growth + 4);
-                    BlockGrowEvent ev = new BlockGrowEvent(this, block);
-                    Server.getInstance().getPluginManager().callEvent(ev);
-                    if (!ev.isCancelled()) {
-                        this.getLevel().setBlock(this, ev.getNewState(), false, true);
+                    BlockGrowEvent event = new BlockGrowEvent(this, block);
+                    event.call();
+                    if (!event.isCancelled()) {
+                        this.getLevel().setBlock(this, event.getNewState(), false, true);
                     } else {
                         return type;
                     }
@@ -93,10 +92,10 @@ public class BlockCaveVines extends BlockTransparentMeta {
                         block = new BlockCaveVinesHeadWithBerries();
                     } else block = new BlockCaveVinesBodyWithBerries();
                     block.setGrowth(getMaxGrowth());
-                    BlockGrowEvent ev = new BlockGrowEvent(this, block);
-                    Server.getInstance().getPluginManager().callEvent(ev);
-                    if (!ev.isCancelled()) {
-                        this.getLevel().setBlock(this, ev.getNewState(), false, true);
+                    BlockGrowEvent event = new BlockGrowEvent(this, block);
+                    event.call();
+                    if (!event.isCancelled()) {
+                        this.getLevel().setBlock(this, event.getNewState(), false, true);
                     } else {
                         return type;
                     }
@@ -109,20 +108,20 @@ public class BlockCaveVines extends BlockTransparentMeta {
                     block = new BlockCaveVinesHeadWithBerries();
                 } else block = new BlockCaveVinesBodyWithBerries();
                 block.setGrowth(getMaxGrowth());
-                BlockGrowEvent ev = new BlockGrowEvent(this, block);
-                Server.getInstance().getPluginManager().callEvent(ev);
-                if (!ev.isCancelled()) {
-                    this.getLevel().setBlock(this.down(), ev.getNewState(), false, true);
+                BlockGrowEvent event = new BlockGrowEvent(this, block);
+                event.call();
+                if (!event.isCancelled()) {
+                    this.getLevel().setBlock(this.down(), event.getNewState(), false, true);
                 } else {
                     return type;
                 }
             } else if (down().getId() == AIR) {
                 BlockCaveVines block = new BlockCaveVines();
                 block.setGrowth(0);
-                BlockGrowEvent ev = new BlockGrowEvent(this, block);
-                Server.getInstance().getPluginManager().callEvent(ev);
-                if (!ev.isCancelled()) {
-                    this.getLevel().setBlock(this.down(), ev.getNewState(), false, true);
+                BlockGrowEvent event = new BlockGrowEvent(this, block);
+                event.call();
+                if (!event.isCancelled()) {
+                    this.getLevel().setBlock(this.down(), event.getNewState(), false, true);
                 }
             }
             return type;
@@ -141,12 +140,12 @@ public class BlockCaveVines extends BlockTransparentMeta {
             int growth = getGrowth();
             if (growth < max) {
                 block.setGrowth(max);
-                BlockGrowEvent ev = new BlockGrowEvent(this, block);
-                Server.getInstance().getPluginManager().callEvent(ev);
-                if (ev.isCancelled()) {
+                BlockGrowEvent event = new BlockGrowEvent(this, block);
+                event.call();
+                if (event.isCancelled()) {
                     return false;
                 }
-                this.getLevel().setBlock(this, ev.getNewState(), false, true);
+                this.getLevel().setBlock(this, event.getNewState(), false, true);
                 this.level.addParticle(new BoneMealParticle(this));
                 if (player != null && !player.isCreative()) {
                     item.count--;

--- a/src/main/java/cn/nukkit/block/BlockCherrySapling.java
+++ b/src/main/java/cn/nukkit/block/BlockCherrySapling.java
@@ -87,15 +87,15 @@ public class BlockCherrySapling extends BlockFlowable implements BlockFlowerPot.
         Vector3 vector3 = new Vector3(this.x, this.y - 1, this.z);
         var objectCherryTree = new ObjectCherryTree();
         objectCherryTree.generate(chunkManager, new NukkitRandom(), this);
-        StructureGrowEvent ev = new StructureGrowEvent(this, chunkManager.getBlocks());
-        this.level.getServer().getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        StructureGrowEvent event = new StructureGrowEvent(this, chunkManager.getBlocks());
+        event.call();
+        if (event.isCancelled()) {
             return;
         }
         if (this.level.getBlock(vector3).getId() == BlockID.DIRT_WITH_ROOTS) {
             this.level.setBlock(vector3, Block.get(BlockID.DIRT));
         }
-        for (Block block : ev.getBlockList()) {
+        for (Block block : event.getBlockList()) {
             if (block.getId() == BlockID.AIR) continue;
             this.level.setBlock(block, block);
         }

--- a/src/main/java/cn/nukkit/block/BlockChorusFlower.java
+++ b/src/main/java/cn/nukkit/block/BlockChorusFlower.java
@@ -1,6 +1,5 @@
 package cn.nukkit.block;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockproperty.BlockProperties;
@@ -137,12 +136,12 @@ public class BlockChorusFlower extends BlockTransparentMeta {
                     if (growUp && this.up(2).getId() == AIR && isHorizontalAir(this.up())) {
                         BlockChorusFlower block = (BlockChorusFlower) this.clone();
                         block.y = this.y + 1;
-                        BlockGrowEvent ev = new BlockGrowEvent(this, block);
-                        Server.getInstance().getPluginManager().callEvent(ev);
+                        BlockGrowEvent event = new BlockGrowEvent(this, block);
+                        event.call();
 
-                        if (!ev.isCancelled()) {
+                        if (!event.isCancelled()) {
                             this.getLevel().setBlock(this, Block.get(CHORUS_PLANT));
-                            this.getLevel().setBlock(block, ev.getNewState());
+                            this.getLevel().setBlock(block, event.getNewState());
                             this.getLevel().addSound(this.add(0.5, 0.5, 0.5), Sound.BLOCK_CHORUSFLOWER_GROW);
                         } else {
                             return Level.BLOCK_UPDATE_RANDOM;
@@ -160,12 +159,12 @@ public class BlockChorusFlower extends BlockTransparentMeta {
                                 block.y = check.y;
                                 block.z = check.z;
                                 block.setAge(getAge() + 1);
-                                BlockGrowEvent ev = new BlockGrowEvent(this, block);
-                                Server.getInstance().getPluginManager().callEvent(ev);
+                                BlockGrowEvent event = new BlockGrowEvent(this, block);
+                                event.call();
 
-                                if (!ev.isCancelled()) {
+                                if (!event.isCancelled()) {
                                     this.getLevel().setBlock(this, Block.get(CHORUS_PLANT));
-                                    this.getLevel().setBlock(block, ev.getNewState());
+                                    this.getLevel().setBlock(block, event.getNewState());
                                     this.getLevel().addSound(this.add(0.5, 0.5, 0.5), Sound.BLOCK_CHORUSFLOWER_GROW);
                                 } else {
                                     return Level.BLOCK_UPDATE_RANDOM;
@@ -176,11 +175,11 @@ public class BlockChorusFlower extends BlockTransparentMeta {
                     } else {
                         BlockChorusFlower block = (BlockChorusFlower) this.clone();
                         block.setAge(getMaxAge());
-                        BlockGrowEvent ev = new BlockGrowEvent(this, block);
-                        Server.getInstance().getPluginManager().callEvent(ev);
+                        BlockGrowEvent event = new BlockGrowEvent(this, block);
+                        event.call();
 
-                        if (!ev.isCancelled()) {
-                            this.getLevel().setBlock(block, ev.getNewState());
+                        if (!event.isCancelled()) {
+                            this.getLevel().setBlock(block, event.getNewState());
                             this.getLevel().addSound(this.add(0.5, 0.5, 0.5), Sound.BLOCK_CHORUSFLOWER_DEATH);
                         } else {
                             return Level.BLOCK_UPDATE_RANDOM;

--- a/src/main/java/cn/nukkit/block/BlockCocoa.java
+++ b/src/main/java/cn/nukkit/block/BlockCocoa.java
@@ -2,7 +2,6 @@ package cn.nukkit.block;
 
 import static cn.nukkit.blockproperty.CommonBlockProperties.DIRECTION;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockproperty.BlockProperties;
@@ -231,9 +230,9 @@ public class BlockCocoa extends BlockTransparentMeta implements Faceable {
     public boolean grow() {
         Block block = this.clone();
         block.setDamage(block.getDamage() + 4);
-        BlockGrowEvent ev = new BlockGrowEvent(this, block);
-        Server.getInstance().getPluginManager().callEvent(ev);
-        return !ev.isCancelled() && this.getLevel().setBlock(this, ev.getNewState(), true, true);
+        BlockGrowEvent event = new BlockGrowEvent(this, block);
+        event.call();
+        return !event.isCancelled() && this.getLevel().setBlock(this, event.getNewState(), true, true);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockComposter.java
+++ b/src/main/java/cn/nukkit/block/BlockComposter.java
@@ -138,7 +138,7 @@ public class BlockComposter extends BlockSolidMeta implements ItemID {
         if (isFull()) {
             ComposterEmptyEvent event =
                     new ComposterEmptyEvent(this, player, item, MinecraftItemID.BONE_MEAL.get(1), 0);
-            this.level.getServer().getPluginManager().callEvent(event);
+            event.call();
             if (!event.isCancelled()) {
                 setDamage(event.getNewLevel());
                 this.level.setBlock(this, this, true, true);
@@ -155,7 +155,7 @@ public class BlockComposter extends BlockSolidMeta implements ItemID {
 
         boolean success = new Random().nextInt(100) < chance;
         ComposterFillEvent event = new ComposterFillEvent(this, player, item, chance, success);
-        this.level.getServer().getPluginManager().callEvent(event);
+        event.call();
 
         if (event.isCancelled()) {
             return true;
@@ -187,7 +187,7 @@ public class BlockComposter extends BlockSolidMeta implements ItemID {
     @PowerNukkitDifference
     public Item empty(@Nullable Item item, @Nullable Player player) {
         ComposterEmptyEvent event = new ComposterEmptyEvent(this, player, item, new ItemDye(DyeColor.BONE_MEAL), 0);
-        this.level.getServer().getPluginManager().callEvent(event);
+        event.call();
         if (!event.isCancelled()) {
             setPropertyValue(COMPOSTER_FILL_LEVEL, event.getNewLevel());
             this.level.setBlock(this, this, true, true);

--- a/src/main/java/cn/nukkit/block/BlockCrops.java
+++ b/src/main/java/cn/nukkit/block/BlockCrops.java
@@ -1,6 +1,5 @@
 package cn.nukkit.block;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockproperty.BlockProperties;
@@ -102,14 +101,14 @@ public abstract class BlockCrops extends BlockFlowable {
                 BlockCrops block = (BlockCrops) this.clone();
                 growth += ThreadLocalRandom.current().nextInt(3) + 2;
                 block.setGrowth(Math.min(growth, max));
-                BlockGrowEvent ev = new BlockGrowEvent(this, block);
-                Server.getInstance().getPluginManager().callEvent(ev);
+                BlockGrowEvent event = new BlockGrowEvent(this, block);
+                event.call();
 
-                if (ev.isCancelled()) {
+                if (event.isCancelled()) {
                     return false;
                 }
 
-                this.getLevel().setBlock(this, ev.getNewState(), false, true);
+                this.getLevel().setBlock(this, event.getNewState(), false, true);
                 this.level.addParticle(new BoneMealParticle(this));
 
                 if (player != null && !player.isCreative()) {
@@ -137,11 +136,11 @@ public abstract class BlockCrops extends BlockFlowable {
                 if (growth < getMaxGrowth()) {
                     BlockCrops block = (BlockCrops) this.clone();
                     block.setGrowth(growth + 1);
-                    BlockGrowEvent ev = new BlockGrowEvent(this, block);
-                    Server.getInstance().getPluginManager().callEvent(ev);
+                    BlockGrowEvent event = new BlockGrowEvent(this, block);
+                    event.call();
 
-                    if (!ev.isCancelled()) {
-                        this.getLevel().setBlock(this, ev.getNewState(), false, true);
+                    if (!event.isCancelled()) {
+                        this.getLevel().setBlock(this, event.getNewState(), false, true);
                     } else {
                         return Level.BLOCK_UPDATE_RANDOM;
                     }

--- a/src/main/java/cn/nukkit/block/BlockCropsStem.java
+++ b/src/main/java/cn/nukkit/block/BlockCropsStem.java
@@ -20,7 +20,6 @@ package cn.nukkit.block;
 
 import static cn.nukkit.blockproperty.CommonBlockProperties.FACING_DIRECTION;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockproperty.BlockProperties;
@@ -128,10 +127,10 @@ public abstract class BlockCropsStem extends BlockCrops implements Faceable {
         if (growth < GROWTH.getMaxValue()) {
             BlockCropsStem block = this.clone();
             block.setGrowth(growth + 1);
-            BlockGrowEvent ev = new BlockGrowEvent(this, block);
-            Server.getInstance().getPluginManager().callEvent(ev);
-            if (!ev.isCancelled()) {
-                this.getLevel().setBlock(this, ev.getNewState(), true);
+            BlockGrowEvent event = new BlockGrowEvent(this, block);
+            event.call();
+            if (!event.isCancelled()) {
+                this.getLevel().setBlock(this, event.getNewState(), true);
             }
             return Level.BLOCK_UPDATE_RANDOM;
         }
@@ -155,10 +154,10 @@ public abstract class BlockCropsStem extends BlockCrops implements Faceable {
         Block side = this.getSide(sideFace);
         Block d = side.down();
         if (side.getId() == AIR && (d.getId() == FARMLAND || d.getId() == GRASS || d.getId() == DIRT)) {
-            BlockGrowEvent ev = new BlockGrowEvent(side, Block.get(fruitId));
-            Server.getInstance().getPluginManager().callEvent(ev);
-            if (!ev.isCancelled()) {
-                this.getLevel().setBlock(side, ev.getNewState(), true);
+            BlockGrowEvent event = new BlockGrowEvent(side, Block.get(fruitId));
+            event.call();
+            if (!event.isCancelled()) {
+                this.getLevel().setBlock(side, event.getNewState(), true);
                 setBlockFace(sideFace);
                 this.getLevel().setBlock(this, this, true);
             }

--- a/src/main/java/cn/nukkit/block/BlockDoor.java
+++ b/src/main/java/cn/nukkit/block/BlockDoor.java
@@ -206,9 +206,7 @@ public abstract class BlockDoor extends BlockTransparentMeta implements Redstone
     private void onRedstoneUpdate() {
         if ((this.isOpen() != this.isGettingPower()) && !this.getManualOverride()) {
             if (this.isOpen() != this.isGettingPower()) {
-                level.getServer()
-                        .getPluginManager()
-                        .callEvent(new BlockRedstoneEvent(this, this.isOpen() ? 15 : 0, this.isOpen() ? 0 : 15));
+                new BlockRedstoneEvent(this, this.isOpen() ? 15 : 0, this.isOpen() ? 0 : 15).call();
 
                 this.setOpen(null, this.isGettingPower());
             }
@@ -406,7 +404,7 @@ public abstract class BlockDoor extends BlockTransparentMeta implements Redstone
         }
 
         DoorToggleEvent event = new DoorToggleEvent(this, player);
-        level.getServer().getPluginManager().callEvent(event);
+        event.call();
 
         if (event.isCancelled()) {
             return false;

--- a/src/main/java/cn/nukkit/block/BlockDragonEgg.java
+++ b/src/main/java/cn/nukkit/block/BlockDragonEgg.java
@@ -79,7 +79,7 @@ public class BlockDragonEgg extends BlockFallable {
                     .getBlock(this.add(random.nextInt(-16, 16), random.nextInt(0, 16), random.nextInt(-16, 16)));
             if (to.getId() == AIR) {
                 BlockFromToEvent event = new BlockFromToEvent(this, to);
-                this.level.getServer().getPluginManager().callEvent(event);
+                event.call();
                 if (event.isCancelled()) return;
                 to = event.getTo();
 

--- a/src/main/java/cn/nukkit/block/BlockFallable.java
+++ b/src/main/java/cn/nukkit/block/BlockFallable.java
@@ -23,7 +23,7 @@ public abstract class BlockFallable extends BlockSolid {
                     || down instanceof BlockLiquid
                     || (down instanceof BlockBubbleColumn && down.getLevelBlockAtLayer(1) instanceof BlockLiquid))) {
                 BlockFallEvent event = new BlockFallEvent(this);
-                this.level.getServer().getPluginManager().callEvent(event);
+                event.call();
                 if (event.isCancelled()) {
                     return type;
                 }

--- a/src/main/java/cn/nukkit/block/BlockFarmland.java
+++ b/src/main/java/cn/nukkit/block/BlockFarmland.java
@@ -76,8 +76,8 @@ public class BlockFarmland extends BlockTransparentMeta {
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_NORMAL) {
             if (this.up().isSolid()) {
-                var farmEvent = new FarmLandDecayEvent(null, this);
-                this.level.getServer().getPluginManager().callEvent(farmEvent);
+                FarmLandDecayEvent farmEvent = new FarmLandDecayEvent(null, this);
+                farmEvent.call();
                 if (farmEvent.isCancelled()) return 0;
 
                 this.level.setBlock(this, Block.get(BlockID.DIRT), false, true);
@@ -134,8 +134,8 @@ public class BlockFarmland extends BlockTransparentMeta {
                 this.setDamage(damage - 1);
                 this.level.setBlock(this, this, false, damage == 1);
             } else {
-                var farmEvent = new FarmLandDecayEvent(null, this);
-                this.level.getServer().getPluginManager().callEvent(farmEvent);
+                FarmLandDecayEvent farmEvent = new FarmLandDecayEvent(null, this);
+                farmEvent.call();
                 if (farmEvent.isCancelled()) return 0;
                 this.level.setBlock(this, Block.get(Block.DIRT), false, true);
             }

--- a/src/main/java/cn/nukkit/block/BlockFenceGate.java
+++ b/src/main/java/cn/nukkit/block/BlockFenceGate.java
@@ -197,7 +197,7 @@ public class BlockFenceGate extends BlockTransparentMeta implements RedstoneComp
         }
 
         DoorToggleEvent event = new DoorToggleEvent(this, player);
-        this.getLevel().getServer().getPluginManager().callEvent(event);
+        event.call();
 
         if (event.isCancelled()) {
             return false;
@@ -312,9 +312,7 @@ public class BlockFenceGate extends BlockTransparentMeta implements RedstoneComp
     private void onRedstoneUpdate() {
         if ((this.isOpen() != this.isGettingPower()) && !this.getManualOverride()) {
             if (this.isOpen() != this.isGettingPower()) {
-                level.getServer()
-                        .getPluginManager()
-                        .callEvent(new BlockRedstoneEvent(this, this.isOpen() ? 15 : 0, this.isOpen() ? 0 : 15));
+                new BlockRedstoneEvent(this, this.isOpen() ? 15 : 0, this.isOpen() ? 0 : 15).call();
 
                 this.setOpen(null, this.isGettingPower());
             }

--- a/src/main/java/cn/nukkit/block/BlockFire.java
+++ b/src/main/java/cn/nukkit/block/BlockFire.java
@@ -1,6 +1,5 @@
 package cn.nukkit.block;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitDifference;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.PowerNukkitXOnly;
@@ -91,13 +90,13 @@ public class BlockFire extends BlockFlowable {
             entity.attack(new EntityDamageByBlockEvent(this, entity, DamageCause.FIRE, 1));
         }
 
-        EntityCombustByBlockEvent ev = new EntityCombustByBlockEvent(this, entity, 8);
+        EntityCombustByBlockEvent event = new EntityCombustByBlockEvent(this, entity, 8);
         if (entity instanceof EntityArrow) {
-            ev.setCancelled();
+            event.cancel();
         }
-        Server.getInstance().getPluginManager().callEvent(ev);
-        if (!ev.isCancelled() && entity.isAlive() && entity.noDamageTicks == 0) {
-            entity.setOnFire(ev.getDuration());
+        event.call();
+        if (!event.isCancelled() && entity.isAlive() && entity.noDamageTicks == 0) {
+            entity.setOnFire(event.getDuration());
         }
     }
 
@@ -128,7 +127,7 @@ public class BlockFire extends BlockFlowable {
 
             if (!this.isBlockTopFacingSurfaceSolid(down) && !this.canNeighborBurn()) {
                 BlockFadeEvent event = new BlockFadeEvent(this, get(AIR));
-                level.getServer().getPluginManager().callEvent(event);
+                event.call();
                 if (!event.isCancelled()) {
                     level.setBlock(this, event.getNewState(), true);
                 }
@@ -150,7 +149,7 @@ public class BlockFire extends BlockFlowable {
 
             if (!this.isBlockTopFacingSurfaceSolid(down) && !this.canNeighborBurn()) {
                 BlockFadeEvent event = new BlockFadeEvent(this, get(AIR));
-                level.getServer().getPluginManager().callEvent(event);
+                event.call();
                 if (!event.isCancelled()) {
                     level.setBlock(this, event.getNewState(), true);
                 }
@@ -174,14 +173,14 @@ public class BlockFire extends BlockFlowable {
                 if (!forever && !this.canNeighborBurn()) {
                     if (!this.isBlockTopFacingSurfaceSolid(down) || meta > 3) {
                         BlockFadeEvent event = new BlockFadeEvent(this, get(AIR));
-                        level.getServer().getPluginManager().callEvent(event);
+                        event.call();
                         if (!event.isCancelled()) {
                             level.setBlock(this, event.getNewState(), true);
                         }
                     }
                 } else if (!forever && !(down.getBurnAbility() > 0) && meta == 15 && random.nextInt(4) == 0) {
                     BlockFadeEvent event = new BlockFadeEvent(this, get(AIR));
-                    level.getServer().getPluginManager().callEvent(event);
+                    event.call();
                     if (!event.isCancelled()) {
                         level.setBlock(this, event.getNewState(), true);
                     }
@@ -228,14 +227,11 @@ public class BlockFire extends BlockFlowable {
                                                 damage = 15;
                                             }
 
-                                            BlockIgniteEvent e = new BlockIgniteEvent(
+                                            BlockIgniteEvent event = new BlockIgniteEvent(
                                                     block, this, null, BlockIgniteEvent.BlockIgniteCause.SPREAD);
-                                            this.level
-                                                    .getServer()
-                                                    .getPluginManager()
-                                                    .callEvent(e);
+                                            event.call();
 
-                                            if (!e.isCancelled()) {
+                                            if (!event.isCancelled()) {
                                                 this.getLevel().setBlock(block, Block.get(BlockID.FIRE, damage), true);
                                                 this.getLevel().scheduleUpdate(block, this.tickRate());
                                             }
@@ -266,18 +262,19 @@ public class BlockFire extends BlockFlowable {
                     meta = 15;
                 }
 
-                BlockIgniteEvent e = new BlockIgniteEvent(block, this, null, BlockIgniteEvent.BlockIgniteCause.SPREAD);
-                this.level.getServer().getPluginManager().callEvent(e);
+                BlockIgniteEvent event =
+                        new BlockIgniteEvent(block, this, null, BlockIgniteEvent.BlockIgniteCause.SPREAD);
+                event.call();
 
-                if (!e.isCancelled()) {
+                if (!event.isCancelled()) {
                     this.getLevel().setBlock(block, Block.get(BlockID.FIRE, meta), true);
                     this.getLevel().scheduleUpdate(block, this.tickRate());
                 }
             } else {
-                BlockBurnEvent ev = new BlockBurnEvent(block);
-                this.getLevel().getServer().getPluginManager().callEvent(ev);
+                BlockBurnEvent event = new BlockBurnEvent(block);
+                event.call();
 
-                if (!ev.isCancelled()) {
+                if (!event.isCancelled()) {
                     this.getLevel().setBlock(block, Block.get(BlockID.AIR), true);
                 }
             }
@@ -370,7 +367,7 @@ public class BlockFire extends BlockFlowable {
                         || this.getLevel().canBlockSeeSky(this.south())
                         || this.getLevel().canBlockSeeSky(this.north()))) {
             BlockFadeEvent event = new BlockFadeEvent(this, get(AIR));
-            level.getServer().getPluginManager().callEvent(event);
+            event.call();
             if (!event.isCancelled()) {
                 level.setBlock(this, event.getNewState(), true);
             }

--- a/src/main/java/cn/nukkit/block/BlockGrass.java
+++ b/src/main/java/cn/nukkit/block/BlockGrass.java
@@ -1,6 +1,5 @@
 package cn.nukkit.block;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitDifference;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
@@ -128,10 +127,10 @@ public class BlockGrass extends BlockDirt {
             // but only if they cause the light level above the grass block to be four or below (like water does),
             // and the surrounding area is not otherwise sufficiently lit up.
             if (up().getLightFilter() > 1) {
-                BlockFadeEvent ev = new BlockFadeEvent(this, Block.get(BlockID.DIRT));
-                Server.getInstance().getPluginManager().callEvent(ev);
-                if (!ev.isCancelled()) {
-                    this.getLevel().setBlock(this, ev.getNewState());
+                BlockFadeEvent event = new BlockFadeEvent(this, Block.get(BlockID.DIRT));
+                event.call();
+                if (!event.isCancelled()) {
+                    this.getLevel().setBlock(this, event.getNewState());
                     return type;
                 }
             }
@@ -160,10 +159,10 @@ public class BlockGrass extends BlockDirt {
 
                         // Any block directly above the dirt block must not reduce light by 2 levels or more.
                         && block.up().getLightFilter() < 2) {
-                    BlockSpreadEvent ev = new BlockSpreadEvent(block, this, Block.get(BlockID.GRASS));
-                    Server.getInstance().getPluginManager().callEvent(ev);
-                    if (!ev.isCancelled()) {
-                        this.getLevel().setBlock(block, ev.getNewState());
+                    BlockSpreadEvent event = new BlockSpreadEvent(block, this, Block.get(BlockID.GRASS));
+                    event.call();
+                    if (!event.isCancelled()) {
+                        this.getLevel().setBlock(block, event.getNewState());
                     }
                 }
             }

--- a/src/main/java/cn/nukkit/block/BlockHopper.java
+++ b/src/main/java/cn/nukkit/block/BlockHopper.java
@@ -3,7 +3,6 @@ package cn.nukkit.block;
 import static cn.nukkit.blockproperty.CommonBlockProperties.FACING_DIRECTION;
 import static cn.nukkit.blockproperty.CommonBlockProperties.TOGGLE;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.*;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.blockentity.BlockEntityHopper;
@@ -270,11 +269,11 @@ public class BlockHopper extends BlockTransparentMeta
 
                         if (!hopperInv.canAddItem(itemToAdd)) continue;
 
-                        InventoryMoveItemEvent ev = new InventoryMoveItemEvent(
+                        InventoryMoveItemEvent event = new InventoryMoveItemEvent(
                                 inv, hopperInv, hopperHolder, itemToAdd, InventoryMoveItemEvent.Action.SLOT_CHANGE);
-                        Server.getInstance().getPluginManager().callEvent(ev);
+                        event.call();
 
-                        if (ev.isCancelled()) continue;
+                        if (event.isCancelled()) continue;
 
                         Item[] items = hopperInv.addItem(itemToAdd);
 
@@ -323,11 +322,11 @@ public class BlockHopper extends BlockTransparentMeta
 
                 int originalCount = item.getCount();
 
-                InventoryMoveItemEvent ev = new InventoryMoveItemEvent(
+                InventoryMoveItemEvent event = new InventoryMoveItemEvent(
                         null, hopperInv, hopperHolder, item, InventoryMoveItemEvent.Action.PICKUP);
-                Server.getInstance().getPluginManager().callEvent(ev);
+                event.call();
 
-                if (ev.isCancelled()) continue;
+                if (event.isCancelled()) continue;
 
                 Item[] items = hopperInv.addItem(item);
 

--- a/src/main/java/cn/nukkit/block/BlockIce.java
+++ b/src/main/java/cn/nukkit/block/BlockIce.java
@@ -64,7 +64,7 @@ public class BlockIce extends BlockTransparent {
             if (level.getBlockLightAt((int) this.x, (int) this.y, (int) this.z) >= 12) {
                 BlockFadeEvent event = new BlockFadeEvent(
                         this, level.getDimension() == Level.DIMENSION_NETHER ? get(AIR) : get(FLOWING_WATER));
-                level.getServer().getPluginManager().callEvent(event);
+                event.call();
                 if (!event.isCancelled()) {
                     level.setBlock(this, event.getNewState(), true);
                 }

--- a/src/main/java/cn/nukkit/block/BlockItemFrame.java
+++ b/src/main/java/cn/nukkit/block/BlockItemFrame.java
@@ -167,7 +167,7 @@ public class BlockItemFrame extends BlockTransparentMeta implements BlockEntityH
             Item itemOnFrame = item.clone();
             ItemFrameUseEvent event =
                     new ItemFrameUseEvent(player, this, itemFrame, itemOnFrame, ItemFrameUseEvent.Action.PUT);
-            this.getLevel().getServer().getPluginManager().callEvent(event);
+            event.call();
             if (event.isCancelled()) return false;
             if (player != null && !player.isCreative()) {
                 itemOnFrame.setCount(itemOnFrame.getCount() - 1);
@@ -183,7 +183,7 @@ public class BlockItemFrame extends BlockTransparentMeta implements BlockEntityH
         } else {
             ItemFrameUseEvent event =
                     new ItemFrameUseEvent(player, this, itemFrame, null, ItemFrameUseEvent.Action.ROTATION);
-            this.getLevel().getServer().getPluginManager().callEvent(event);
+            event.call();
             if (event.isCancelled()) return false;
             itemFrame.setItemRotation((itemFrame.getItemRotation() + 1) % 8);
             if (isStoringMap()) {

--- a/src/main/java/cn/nukkit/block/BlockKelp.java
+++ b/src/main/java/cn/nukkit/block/BlockKelp.java
@@ -1,6 +1,5 @@
 package cn.nukkit.block;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockproperty.BlockProperties;
@@ -143,13 +142,13 @@ public class BlockKelp extends BlockFlowable {
             Block up = up();
             if (up instanceof BlockWater && ((BlockWater) up).isSourceOrFlowingDown()) {
                 Block grown = BlockState.of(BLOCK_KELP, age + 1).getBlock();
-                BlockGrowEvent ev = new BlockGrowEvent(this, grown);
-                Server.getInstance().getPluginManager().callEvent(ev);
-                if (!ev.isCancelled()) {
+                BlockGrowEvent event = new BlockGrowEvent(this, grown);
+                event.call();
+                if (!event.isCancelled()) {
                     this.setAge(maxValue);
                     this.getLevel().setBlock(this, 0, this, true, true);
                     this.getLevel().setBlock(up, 1, get(FLOWING_WATER), true, false);
-                    this.getLevel().setBlock(up, 0, ev.getNewState(), true, true);
+                    this.getLevel().setBlock(up, 0, event.getNewState(), true, true);
                     return true;
                 }
             }

--- a/src/main/java/cn/nukkit/block/BlockLava.java
+++ b/src/main/java/cn/nukkit/block/BlockLava.java
@@ -1,6 +1,5 @@
 package cn.nukkit.block;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.entity.Entity;
@@ -52,13 +51,13 @@ public class BlockLava extends BlockLiquid {
     public void onEntityCollide(Entity entity) {
         entity.highestPosition -= (entity.highestPosition - entity.y) * 0.5;
 
-        EntityCombustByBlockEvent ev = new EntityCombustByBlockEvent(this, entity, 8);
-        Server.getInstance().getPluginManager().callEvent(ev);
-        if (!ev.isCancelled()
+        EntityCombustByBlockEvent event = new EntityCombustByBlockEvent(this, entity, 8);
+        event.call();
+        if (!event.isCancelled()
                 // Making sure the entity is actually alive and not invulnerable.
                 && entity.isAlive()
                 && entity.noDamageTicks == 0) {
-            entity.setOnFire(ev.getDuration());
+            entity.setOnFire(event.getDuration());
         }
 
         if (!entity.hasEffect(Effect.FIRE_RESISTANCE)) {
@@ -100,11 +99,11 @@ public class BlockLava extends BlockLiquid {
 
                     if (block.getId() == AIR) {
                         if (this.isSurroundingBlockFlammable(block)) {
-                            BlockIgniteEvent e =
+                            BlockIgniteEvent event =
                                     new BlockIgniteEvent(block, this, null, BlockIgniteEvent.BlockIgniteCause.LAVA);
-                            this.level.getServer().getPluginManager().callEvent(e);
+                            event.call();
 
-                            if (!e.isCancelled()) {
+                            if (!event.isCancelled()) {
                                 Block fire = Block.get(BlockID.FIRE);
                                 this.getLevel().setBlock(v, fire, true);
                                 this.getLevel().scheduleUpdate(fire, fire.tickRate());
@@ -123,11 +122,11 @@ public class BlockLava extends BlockLiquid {
                     Block block = this.getLevel().getBlock(v);
 
                     if (block.up().getId() == AIR && block.getBurnChance() > 0 && isNetherSpreadNotAllowed(block)) {
-                        BlockIgniteEvent e =
+                        BlockIgniteEvent event =
                                 new BlockIgniteEvent(block, this, null, BlockIgniteEvent.BlockIgniteCause.LAVA);
-                        this.level.getServer().getPluginManager().callEvent(e);
+                        event.call();
 
-                        if (!e.isCancelled()) {
+                        if (!event.isCancelled()) {
                             Block fire = Block.get(BlockID.FIRE);
                             this.getLevel().setBlock(v, fire, true);
                             this.getLevel().scheduleUpdate(fire, fire.tickRate());

--- a/src/main/java/cn/nukkit/block/BlockLeaves.java
+++ b/src/main/java/cn/nukkit/block/BlockLeaves.java
@@ -1,6 +1,5 @@
 package cn.nukkit.block;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.DeprecationDetails;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
@@ -202,9 +201,9 @@ public class BlockLeaves extends BlockTransparentMeta {
                     setCheckDecay(false);
                     getLevel().setBlock(this, this, false, false);
                 } else {
-                    LeavesDecayEvent ev = new LeavesDecayEvent(this);
-                    Server.getInstance().getPluginManager().callEvent(ev);
-                    if (!ev.isCancelled()) {
+                    LeavesDecayEvent event = new LeavesDecayEvent(this);
+                    event.call();
+                    if (!event.isCancelled()) {
                         getLevel().useBreakOn(this);
                     }
                 }

--- a/src/main/java/cn/nukkit/block/BlockLectern.java
+++ b/src/main/java/cn/nukkit/block/BlockLectern.java
@@ -198,7 +198,7 @@ public class BlockLectern extends BlockTransparentMeta
         if (isActivated()) {
             level.cancelSheduledUpdate(this, this);
         } else {
-            this.level.getServer().getPluginManager().callEvent(new BlockRedstoneEvent(this, 0, 15));
+            new BlockRedstoneEvent(this, 0, 15).call();
         }
 
         level.scheduleUpdate(this, this, 4);
@@ -226,7 +226,7 @@ public class BlockLectern extends BlockTransparentMeta
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_SCHEDULED) {
             if (isActivated()) {
-                this.level.getServer().getPluginManager().callEvent(new BlockRedstoneEvent(this, 15, 0));
+                new BlockRedstoneEvent(this, 15, 0).call();
 
                 setActivated(false);
                 level.setBlock(this, this, true, false);
@@ -253,7 +253,7 @@ public class BlockLectern extends BlockTransparentMeta
         }
 
         LecternDropBookEvent dropBookEvent = new LecternDropBookEvent(player, lectern, book);
-        this.getLevel().getServer().getPluginManager().callEvent(dropBookEvent);
+        dropBookEvent.call();
         if (dropBookEvent.isCancelled()) {
             return;
         }

--- a/src/main/java/cn/nukkit/block/BlockLever.java
+++ b/src/main/java/cn/nukkit/block/BlockLever.java
@@ -108,10 +108,7 @@ public class BlockLever extends BlockFlowable implements RedstoneComponent, Face
     @Override
     public boolean onActivate(@NotNull Item item, Player player) {
         if (!player.getAdventureSettings().get(AdventureSettings.Type.DOORS_AND_SWITCHED)) return false;
-        this.level
-                .getServer()
-                .getPluginManager()
-                .callEvent(new BlockRedstoneEvent(this, isPowerOn() ? 15 : 0, isPowerOn() ? 0 : 15));
+        new BlockRedstoneEvent(this, isPowerOn() ? 15 : 0, isPowerOn() ? 0 : 15).call();
         toggleBooleanProperty(OPEN);
         var pos = this.add(0.5, 0.5, 0.5);
         if (isPowerOn()) {

--- a/src/main/java/cn/nukkit/block/BlockLiquid.java
+++ b/src/main/java/cn/nukkit/block/BlockLiquid.java
@@ -293,7 +293,7 @@ public abstract class BlockLiquid extends BlockTransparentMeta {
                         to = getBlock(decay);
                     }
                     BlockFromToEvent event = new BlockFromToEvent(this, to);
-                    level.getServer().getPluginManager().callEvent(event);
+                    event.call();
                     if (!event.isCancelled()) {
                         this.level.setBlock(this, layer, event.getTo(), true, true);
                         if (!decayed) {
@@ -355,7 +355,7 @@ public abstract class BlockLiquid extends BlockTransparentMeta {
             }
 
             LiquidFlowEvent event = new LiquidFlowEvent(block, this, newFlowDecay);
-            level.getServer().getPluginManager().callEvent(event);
+            event.call();
             if (!event.isCancelled()) {
                 if (block.layer == 0 && block.getId() > 0) {
                     this.level.useBreakOn(block, block.getId() == COBWEB ? Item.get(Item.WOODEN_SWORD) : null);
@@ -518,7 +518,7 @@ public abstract class BlockLiquid extends BlockTransparentMeta {
     @PowerNukkitDifference(info = "Using new method to play sounds", since = "1.4.0.0-PN")
     protected boolean liquidCollide(Block cause, Block result) {
         BlockFromToEvent event = new BlockFromToEvent(this, result);
-        this.level.getServer().getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) {
             return false;
         }

--- a/src/main/java/cn/nukkit/block/BlockMushroom.java
+++ b/src/main/java/cn/nukkit/block/BlockMushroom.java
@@ -92,12 +92,12 @@ public abstract class BlockMushroom extends BlockFlowable implements BlockFlower
 
         ListChunkManager chunkManager = new ListChunkManager(this.level);
         if (generator.generate(chunkManager, new NukkitRandom(), this)) {
-            StructureGrowEvent ev = new StructureGrowEvent(this, chunkManager.getBlocks());
-            this.level.getServer().getPluginManager().callEvent(ev);
-            if (ev.isCancelled()) {
+            StructureGrowEvent event = new StructureGrowEvent(this, chunkManager.getBlocks());
+            event.call();
+            if (event.isCancelled()) {
                 return false;
             }
-            for (Block block : ev.getBlockList()) {
+            for (Block block : event.getBlockList()) {
                 this.level.setBlockAt(
                         block.getFloorX(), block.getFloorY(), block.getFloorZ(), block.getId(), block.getDamage());
             }

--- a/src/main/java/cn/nukkit/block/BlockMycelium.java
+++ b/src/main/java/cn/nukkit/block/BlockMycelium.java
@@ -1,6 +1,5 @@
 package cn.nukkit.block;
 
-import cn.nukkit.Server;
 import cn.nukkit.event.block.BlockSpreadEvent;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
@@ -62,10 +61,10 @@ public class BlockMycelium extends BlockSolid {
                 Block block = this.getLevel().getBlock(new Vector3(x, y, z));
                 if (block.getId() == Block.DIRT && block.getDamage() == 0) {
                     if (block.up().isTransparent()) {
-                        BlockSpreadEvent ev = new BlockSpreadEvent(block, this, Block.get(BlockID.MYCELIUM));
-                        Server.getInstance().getPluginManager().callEvent(ev);
-                        if (!ev.isCancelled()) {
-                            this.getLevel().setBlock(block, ev.getNewState());
+                        BlockSpreadEvent event = new BlockSpreadEvent(block, this, Block.get(BlockID.MYCELIUM));
+                        event.call();
+                        if (!event.isCancelled()) {
+                            this.getLevel().setBlock(block, event.getNewState());
                         }
                     }
                 }

--- a/src/main/java/cn/nukkit/block/BlockNetherWart.java
+++ b/src/main/java/cn/nukkit/block/BlockNetherWart.java
@@ -1,6 +1,5 @@
 package cn.nukkit.block;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockproperty.BlockProperties;
@@ -66,11 +65,11 @@ public class BlockNetherWart extends BlockFlowable {
                 if (this.getDamage() < 0x03) {
                     BlockNetherWart block = (BlockNetherWart) this.clone();
                     block.setDamage(block.getDamage() + 1);
-                    BlockGrowEvent ev = new BlockGrowEvent(this, block);
-                    Server.getInstance().getPluginManager().callEvent(ev);
+                    BlockGrowEvent event = new BlockGrowEvent(this, block);
+                    event.call();
 
-                    if (!ev.isCancelled()) {
-                        this.getLevel().setBlock(this, ev.getNewState(), true, true);
+                    if (!event.isCancelled()) {
+                        this.getLevel().setBlock(this, event.getNewState(), true, true);
                     } else {
                         return Level.BLOCK_UPDATE_RANDOM;
                     }

--- a/src/main/java/cn/nukkit/block/BlockObserver.java
+++ b/src/main/java/cn/nukkit/block/BlockObserver.java
@@ -17,7 +17,6 @@ import cn.nukkit.item.ItemTool;
 import cn.nukkit.level.Level;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.player.Player;
-import cn.nukkit.plugin.PluginManager;
 import cn.nukkit.utils.Faceable;
 import cn.nukkit.utils.RedstoneComponent;
 import javax.annotation.Nullable;
@@ -119,15 +118,14 @@ public class BlockObserver extends BlockSolidMeta implements RedstoneComponent, 
     @Override
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_SCHEDULED || type == Level.BLOCK_UPDATE_MOVED) {
-            RedstoneUpdateEvent ev = new RedstoneUpdateEvent(this);
-            PluginManager pluginManager = level.getServer().getPluginManager();
-            pluginManager.callEvent(ev);
-            if (ev.isCancelled()) {
+            RedstoneUpdateEvent event = new RedstoneUpdateEvent(this);
+            event.call();
+            if (event.isCancelled()) {
                 return 0;
             }
 
             if (!isPowered()) {
-                level.getServer().getPluginManager().callEvent(new BlockRedstoneEvent(this, 0, 15));
+                new BlockRedstoneEvent(this, 0, 15).call();
                 setPowered(true);
 
                 if (level.setBlock(this, this)) {
@@ -137,7 +135,7 @@ public class BlockObserver extends BlockSolidMeta implements RedstoneComponent, 
                     level.scheduleUpdate(this, 2);
                 }
             } else {
-                pluginManager.callEvent(new BlockRedstoneEvent(this, 15, 0));
+                new BlockRedstoneEvent(this, 15, 0).call();
                 setPowered(false);
 
                 level.setBlock(this, this);
@@ -159,9 +157,9 @@ public class BlockObserver extends BlockSolidMeta implements RedstoneComponent, 
             return;
         }
 
-        RedstoneUpdateEvent ev = new RedstoneUpdateEvent(this);
-        server.getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        RedstoneUpdateEvent event = new RedstoneUpdateEvent(this);
+        event.call();
+        if (event.isCancelled()) {
             return;
         }
 

--- a/src/main/java/cn/nukkit/block/BlockPistonBase.java
+++ b/src/main/java/cn/nukkit/block/BlockPistonBase.java
@@ -265,7 +265,7 @@ public abstract class BlockPistonBase extends BlockTransparentMeta
         List<BlockVector3> toMoveBlockVec = new ArrayList<>();
         var event = new BlockPistonEvent(
                 this, pistonFace, calculator.getBlocksToMove(), calculator.getBlocksToDestroy(), extending);
-        this.level.getServer().getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) return false;
         var oldPosList = new ArrayList<Vector3>();
         var blockEntityHolderList = new ArrayList<BlockEntityHolder<?>>();

--- a/src/main/java/cn/nukkit/block/BlockPointedDripstone.java
+++ b/src/main/java/cn/nukkit/block/BlockPointedDripstone.java
@@ -2,7 +2,6 @@ package cn.nukkit.block;
 
 import static cn.nukkit.potion.Effect.getEffect;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
@@ -165,7 +164,7 @@ public class BlockPointedDripstone extends BlockFallableMeta {
         if (!blockUp.getSide(BlockFace.UP).isSolid()) AirUp = true;
         if (AirUp) {
             BlockFallEvent event = new BlockFallEvent(this);
-            Server.getInstance().getPluginManager().callEvent(event);
+            event.call();
             if (event.isCancelled()) {
                 return;
             }
@@ -443,7 +442,7 @@ public class BlockPointedDripstone extends BlockFallableMeta {
                         && nextDouble <= 15.0 / 256.0) {
                     CauldronFilledByDrippingLiquidEvent event =
                             new CauldronFilledByDrippingLiquidEvent(cauldron, CauldronLiquid.LAVA, 1);
-                    Server.getInstance().getPluginManager().callEvent(event);
+                    event.call();
                     if (event.isCancelled()) return;
                     cauldron.setCauldronLiquid(event.getLiquid());
                     cauldron.setFillLevel(cauldron.getFillLevel() + event.getLiquidLevelIncrement());
@@ -458,7 +457,7 @@ public class BlockPointedDripstone extends BlockFallableMeta {
                         && nextDouble <= 45.0 / 256.0) {
                     CauldronFilledByDrippingLiquidEvent event =
                             new CauldronFilledByDrippingLiquidEvent(cauldron, CauldronLiquid.WATER, 1);
-                    Server.getInstance().getPluginManager().callEvent(event);
+                    event.call();
                     if (event.isCancelled()) return;
                     cauldron.setCauldronLiquid(event.getLiquid());
                     cauldron.setFillLevel(cauldron.getFillLevel() + event.getLiquidLevelIncrement());

--- a/src/main/java/cn/nukkit/block/BlockPressurePlateBase.java
+++ b/src/main/java/cn/nukkit/block/BlockPressurePlateBase.java
@@ -169,16 +169,16 @@ public abstract class BlockPressurePlateBase extends BlockFlowable implements Re
         int power = getRedstonePower();
 
         if (power == 0) {
-            Event ev;
+            Event event;
             if (entity instanceof Player) {
-                ev = new PlayerInteractEvent((Player) entity, null, this, null, Action.PHYSICAL);
+                event = new PlayerInteractEvent((Player) entity, null, this, null, Action.PHYSICAL);
             } else {
-                ev = new EntityInteractEvent(entity, this);
+                event = new EntityInteractEvent(entity, this);
             }
 
-            this.level.getServer().getPluginManager().callEvent(ev);
+            event.call();
 
-            if (!ev.isCancelled()) {
+            if (!event.isCancelled()) {
                 updateState(power);
             }
         }
@@ -198,10 +198,10 @@ public abstract class BlockPressurePlateBase extends BlockFlowable implements Re
 
             if (!isPowered && wasPowered) {
                 this.playOffSound();
-                this.level.getServer().getPluginManager().callEvent(new BlockRedstoneEvent(this, 15, 0));
+                new BlockRedstoneEvent(this, 15, 0).call();
             } else if (isPowered && !wasPowered) {
                 this.playOnSound();
-                this.level.getServer().getPluginManager().callEvent(new BlockRedstoneEvent(this, 0, 15));
+                new BlockRedstoneEvent(this, 0, 15).call();
             }
         }
 

--- a/src/main/java/cn/nukkit/block/BlockRedstoneDiode.java
+++ b/src/main/java/cn/nukkit/block/BlockRedstoneDiode.java
@@ -122,9 +122,9 @@ public abstract class BlockRedstoneDiode extends BlockFlowable implements Redsto
                 return Level.BLOCK_UPDATE_NORMAL;
             } else if (this.level.getServer().isRedstoneEnabled()) {
                 // Redstone event
-                RedstoneUpdateEvent ev = new RedstoneUpdateEvent(this);
-                getLevel().getServer().getPluginManager().callEvent(ev);
-                if (ev.isCancelled()) {
+                RedstoneUpdateEvent event = new RedstoneUpdateEvent(this);
+                event.call();
+                if (event.isCancelled()) {
                     return 0;
                 }
 

--- a/src/main/java/cn/nukkit/block/BlockRedstoneLamp.java
+++ b/src/main/java/cn/nukkit/block/BlockRedstoneLamp.java
@@ -76,9 +76,9 @@ public class BlockRedstoneLamp extends BlockSolid implements RedstoneComponent {
 
             if (this.isGettingPower()) {
                 // Redstone event
-                RedstoneUpdateEvent ev = new RedstoneUpdateEvent(this);
-                getLevel().getServer().getPluginManager().callEvent(ev);
-                if (ev.isCancelled()) {
+                RedstoneUpdateEvent event = new RedstoneUpdateEvent(this);
+                event.call();
+                if (event.isCancelled()) {
                     return 0;
                 }
 

--- a/src/main/java/cn/nukkit/block/BlockRedstoneLampLit.java
+++ b/src/main/java/cn/nukkit/block/BlockRedstoneLampLit.java
@@ -51,9 +51,9 @@ public class BlockRedstoneLampLit extends BlockRedstoneLamp implements RedstoneC
 
         if (type == Level.BLOCK_UPDATE_SCHEDULED && !this.isGettingPower()) {
             // Redstone event
-            RedstoneUpdateEvent ev = new RedstoneUpdateEvent(this);
-            this.level.getServer().getPluginManager().callEvent(ev);
-            if (ev.isCancelled()) {
+            RedstoneUpdateEvent event = new RedstoneUpdateEvent(this);
+            event.call();
+            if (event.isCancelled()) {
                 return 0;
             }
 

--- a/src/main/java/cn/nukkit/block/BlockRedstoneTorch.java
+++ b/src/main/java/cn/nukkit/block/BlockRedstoneTorch.java
@@ -95,10 +95,10 @@ public class BlockRedstoneTorch extends BlockTorch implements RedstoneComponent 
             if (type == Level.BLOCK_UPDATE_NORMAL || type == Level.BLOCK_UPDATE_REDSTONE) {
                 this.level.scheduleUpdate(this, tickRate());
             } else if (type == Level.BLOCK_UPDATE_SCHEDULED) {
-                RedstoneUpdateEvent ev = new RedstoneUpdateEvent(this);
-                getLevel().getServer().getPluginManager().callEvent(ev);
+                RedstoneUpdateEvent event = new RedstoneUpdateEvent(this);
+                event.call();
 
-                if (ev.isCancelled()) {
+                if (event.isCancelled()) {
                     return 0;
                 }
 

--- a/src/main/java/cn/nukkit/block/BlockRedstoneTorchUnlit.java
+++ b/src/main/java/cn/nukkit/block/BlockRedstoneTorchUnlit.java
@@ -65,9 +65,9 @@ public class BlockRedstoneTorchUnlit extends BlockTorch implements RedstoneCompo
             if (type == Level.BLOCK_UPDATE_NORMAL || type == Level.BLOCK_UPDATE_REDSTONE) {
                 this.level.scheduleUpdate(this, tickRate());
             } else if (type == Level.BLOCK_UPDATE_SCHEDULED) {
-                RedstoneUpdateEvent ev = new RedstoneUpdateEvent(this);
-                getLevel().getServer().getPluginManager().callEvent(ev);
-                if (ev.isCancelled()) {
+                RedstoneUpdateEvent event = new RedstoneUpdateEvent(this);
+                event.call();
+                if (event.isCancelled()) {
                     return 0;
                 }
 

--- a/src/main/java/cn/nukkit/block/BlockRedstoneWire.java
+++ b/src/main/java/cn/nukkit/block/BlockRedstoneWire.java
@@ -168,7 +168,7 @@ public class BlockRedstoneWire extends BlockFlowable implements RedstoneComponen
         }
 
         if (meta != maxStrength) {
-            this.level.getServer().getPluginManager().callEvent(new BlockRedstoneEvent(this, meta, maxStrength));
+            new BlockRedstoneEvent(this, meta, maxStrength).call();
 
             this.setDamage(maxStrength);
             this.level.setBlock(this, this, false, true);
@@ -234,9 +234,9 @@ public class BlockRedstoneWire extends BlockFlowable implements RedstoneComponen
         }
 
         // Redstone event
-        RedstoneUpdateEvent ev = new RedstoneUpdateEvent(this);
-        getLevel().getServer().getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        RedstoneUpdateEvent event = new RedstoneUpdateEvent(this);
+        event.call();
+        if (event.isCancelled()) {
             return 0;
         }
 

--- a/src/main/java/cn/nukkit/block/BlockSapling.java
+++ b/src/main/java/cn/nukkit/block/BlockSapling.java
@@ -289,15 +289,15 @@ public class BlockSapling extends BlockFlowable implements BlockFlowerPot.Flower
                         new NukkitRandom(),
                         getWoodType(),
                         false);
-                StructureGrowEvent ev = new StructureGrowEvent(this, chunkManager.getBlocks());
-                this.level.getServer().getPluginManager().callEvent(ev);
-                if (ev.isCancelled()) {
+                StructureGrowEvent event = new StructureGrowEvent(this, chunkManager.getBlocks());
+                event.call();
+                if (event.isCancelled()) {
                     return;
                 }
                 if (this.level.getBlock(vector3).getId() == BlockID.DIRT_WITH_ROOTS) {
                     this.level.setBlock(vector3, Block.get(BlockID.DIRT));
                 }
-                for (Block block : ev.getBlockList()) {
+                for (Block block : event.getBlockList()) {
                     this.level.setBlock(block, block);
                 }
                 return;
@@ -314,9 +314,9 @@ public class BlockSapling extends BlockFlowable implements BlockFlowerPot.Flower
 
         ListChunkManager chunkManager = new ListChunkManager(this.level);
         boolean success = generator.generate(chunkManager, new NukkitRandom(), vector3);
-        StructureGrowEvent ev = new StructureGrowEvent(this, chunkManager.getBlocks());
-        this.level.getServer().getPluginManager().callEvent(ev);
-        if (ev.isCancelled() || !success) {
+        StructureGrowEvent event = new StructureGrowEvent(this, chunkManager.getBlocks());
+        event.call();
+        if (event.isCancelled() || !success) {
             if (bigTree) {
                 this.level.setBlock(vector3, this, true, false);
                 this.level.setBlock(vector3.add(1, 0, 0), this, true, false);
@@ -331,7 +331,7 @@ public class BlockSapling extends BlockFlowable implements BlockFlowerPot.Flower
         if (this.level.getBlock(vector3).getId() == BlockID.DIRT_WITH_ROOTS) {
             this.level.setBlock(vector3, Block.get(BlockID.DIRT));
         }
-        for (Block block : ev.getBlockList()) {
+        for (Block block : event.getBlockList()) {
             this.level.setBlock(block, block);
         }
     }

--- a/src/main/java/cn/nukkit/block/BlockSeaPickle.java
+++ b/src/main/java/cn/nukkit/block/BlockSeaPickle.java
@@ -1,6 +1,5 @@
 package cn.nukkit.block;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockproperty.BlockProperties;
@@ -162,7 +161,7 @@ public class BlockSeaPickle extends BlockFlowable {
             block.setDamage(3);
 
             BlockGrowEvent blockGrowEvent = new BlockGrowEvent(this, block);
-            Server.getInstance().getPluginManager().callEvent(blockGrowEvent);
+            blockGrowEvent.call();
 
             if (blockGrowEvent.isCancelled()) {
                 return false;

--- a/src/main/java/cn/nukkit/block/BlockSignBase.java
+++ b/src/main/java/cn/nukkit/block/BlockSignBase.java
@@ -103,7 +103,7 @@ public abstract class BlockSignBase extends BlockTransparentMeta implements Face
                 return;
             }
             SignColorChangeEvent event = new SignColorChangeEvent(this, player, color);
-            this.level.getServer().getPluginManager().callEvent(event);
+            event.call();
             if (event.isCancelled()) {
                 sign.spawnTo(player);
                 return;
@@ -121,7 +121,7 @@ public abstract class BlockSignBase extends BlockTransparentMeta implements Face
                 return;
             }
             SignGlowEvent event = new SignGlowEvent(this, player, true);
-            this.level.getServer().getPluginManager().callEvent(event);
+            event.call();
             if (event.isCancelled()) {
                 sign.spawnTo(player);
                 return;
@@ -135,7 +135,7 @@ public abstract class BlockSignBase extends BlockTransparentMeta implements Face
             return;
         } else if (item instanceof ItemHoneycomb) {
             SignWaxedEvent event = new SignWaxedEvent(this, player, true);
-            this.level.getServer().getPluginManager().callEvent(event);
+            event.call();
             if (event.isCancelled()) {
                 sign.spawnTo(player);
                 return;

--- a/src/main/java/cn/nukkit/block/BlockSkull.java
+++ b/src/main/java/cn/nukkit/block/BlockSkull.java
@@ -169,9 +169,9 @@ public class BlockSkull extends BlockTransparentMeta
             return 0;
         }
 
-        RedstoneUpdateEvent ev = new RedstoneUpdateEvent(this);
-        getLevel().getServer().getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        RedstoneUpdateEvent event = new RedstoneUpdateEvent(this);
+        event.call();
+        if (event.isCancelled()) {
             return 0;
         }
 

--- a/src/main/java/cn/nukkit/block/BlockSnowLayer.java
+++ b/src/main/java/cn/nukkit/block/BlockSnowLayer.java
@@ -293,7 +293,7 @@ public class BlockSnowLayer extends BlockFallableMeta {
                 ? get(AIR)
                 : getCurrentState().withProperty(SNOW_HEIGHT, snowHeight).getBlock(toMelt);
         BlockFadeEvent event = new BlockFadeEvent(toMelt, newState);
-        level.getServer().getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) {
             return false;
         }

--- a/src/main/java/cn/nukkit/block/BlockSugarcane.java
+++ b/src/main/java/cn/nukkit/block/BlockSugarcane.java
@@ -1,6 +1,5 @@
 package cn.nukkit.block;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockproperty.BlockProperties;
@@ -84,11 +83,11 @@ public class BlockSugarcane extends BlockFlowable {
                 for (int i = 1; i <= toGrow; i++) {
                     Block block = this.up(i);
                     if (block.getId() == 0) {
-                        BlockGrowEvent ev = new BlockGrowEvent(block, Block.get(BlockID.REEDS));
-                        Server.getInstance().getPluginManager().callEvent(ev);
+                        BlockGrowEvent event = new BlockGrowEvent(block, Block.get(BlockID.REEDS));
+                        event.call();
 
-                        if (!ev.isCancelled()) {
-                            this.getLevel().setBlock(block, ev.getNewState(), true);
+                        if (!event.isCancelled()) {
+                            this.getLevel().setBlock(block, event.getNewState(), true);
                             success = true;
                         }
                     } else if (block.getId() != REEDS) {
@@ -148,10 +147,10 @@ public class BlockSugarcane extends BlockFlowable {
                 return type;
             }
 
-            BlockGrowEvent ev = new BlockGrowEvent(up, Block.get(BlockID.REEDS));
-            Server.getInstance().getPluginManager().callEvent(ev);
+            BlockGrowEvent event = new BlockGrowEvent(up, Block.get(BlockID.REEDS));
+            event.call();
 
-            if (ev.isCancelled()) {
+            if (event.isCancelled()) {
                 return type;
             }
 

--- a/src/main/java/cn/nukkit/block/BlockSweetBerryBush.java
+++ b/src/main/java/cn/nukkit/block/BlockSweetBerryBush.java
@@ -1,6 +1,5 @@
 package cn.nukkit.block;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockproperty.BlockProperties;
@@ -86,14 +85,14 @@ public class BlockSweetBerryBush extends BlockFlowable {
             if (block.getDamage() > 3) {
                 block.setDamage(3);
             }
-            BlockGrowEvent ev = new BlockGrowEvent(this, block);
-            Server.getInstance().getPluginManager().callEvent(ev);
+            BlockGrowEvent event = new BlockGrowEvent(this, block);
+            event.call();
 
-            if (ev.isCancelled()) {
+            if (event.isCancelled()) {
                 return false;
             }
 
-            this.getLevel().setBlock(this, ev.getNewState(), false, true);
+            this.getLevel().setBlock(this, event.getNewState(), false, true);
             this.level.addParticle(new BoneMealParticle(this));
 
             if (player != null && (player.gamemode & 0x01) == 0) {
@@ -114,8 +113,8 @@ public class BlockSweetBerryBush extends BlockFlowable {
 
         BlockHarvestEvent event =
                 new BlockHarvestEvent(this, new BlockSweetBerryBush(1), new Item[] {new ItemSweetBerries(0, amount)});
+        event.call();
 
-        getLevel().getServer().getPluginManager().callEvent(event);
         if (!event.isCancelled()) {
             getLevel().setBlock(this, event.getNewState(), true, true);
             Item[] drops = event.getDrops();

--- a/src/main/java/cn/nukkit/block/BlockTrapdoor.java
+++ b/src/main/java/cn/nukkit/block/BlockTrapdoor.java
@@ -207,9 +207,7 @@ public class BlockTrapdoor extends BlockTransparentMeta implements RedstoneCompo
         if (type == Level.BLOCK_UPDATE_REDSTONE && this.level.getServer().isRedstoneEnabled()) {
             if ((this.isOpen() != this.isGettingPower()) && !this.getManualOverride()) {
                 if (this.isOpen() != this.isGettingPower()) {
-                    level.getServer()
-                            .getPluginManager()
-                            .callEvent(new BlockRedstoneEvent(this, this.isOpen() ? 15 : 0, this.isOpen() ? 0 : 15));
+                    new BlockRedstoneEvent(this, this.isOpen() ? 15 : 0, this.isOpen() ? 0 : 15).call();
 
                     this.setOpen(null, this.isGettingPower());
                 }
@@ -300,7 +298,7 @@ public class BlockTrapdoor extends BlockTransparentMeta implements RedstoneCompo
         }
 
         DoorToggleEvent event = new DoorToggleEvent(this, player);
-        level.getServer().getPluginManager().callEvent(event);
+        event.call();
 
         if (event.isCancelled()) {
             return false;

--- a/src/main/java/cn/nukkit/block/BlockTripWireHook.java
+++ b/src/main/java/cn/nukkit/block/BlockTripWireHook.java
@@ -223,10 +223,10 @@ public class BlockTripWireHook extends BlockTransparentMeta implements RedstoneC
     private void addSound(Vector3 pos, boolean canConnect, boolean nextPowered, boolean attached, boolean powered) {
         if (nextPowered && !powered) {
             this.level.addLevelSoundEvent(pos, LevelSoundEventPacket.SOUND_POWER_ON);
-            this.level.getServer().getPluginManager().callEvent(new BlockRedstoneEvent(this, 0, 15));
+            new BlockRedstoneEvent(this, 0, 15).call();
         } else if (!nextPowered && powered) {
             this.level.addLevelSoundEvent(pos, LevelSoundEventPacket.SOUND_POWER_OFF);
-            this.level.getServer().getPluginManager().callEvent(new BlockRedstoneEvent(this, 15, 0));
+            new BlockRedstoneEvent(this, 15, 0).call();
         } else if (canConnect && !attached) {
             this.level.addLevelSoundEvent(pos, LevelSoundEventPacket.SOUND_ATTACH);
         } else if (!canConnect && attached) {

--- a/src/main/java/cn/nukkit/block/BlockTurtleEgg.java
+++ b/src/main/java/cn/nukkit/block/BlockTurtleEgg.java
@@ -224,7 +224,7 @@ public class BlockTurtleEgg extends BlockFlowable {
                         BlockTurtleEgg newState = clone();
                         newState.setCracks(crackState.getNext());
                         BlockGrowEvent event = new BlockGrowEvent(this, newState);
-                        this.level.getServer().getPluginManager().callEvent(event);
+                        event.call();
                         if (!event.isCancelled()) {
                             level.addSound(this, Sound.BLOCK_TURTLE_EGG_CRACK, 0.7f, 0.9f + random.nextFloat() * 0.2f);
                             this.level.setBlock(this, event.getNewState(), true, true);
@@ -254,8 +254,8 @@ public class BlockTurtleEgg extends BlockFlowable {
     public void hatch(int eggs, Block newState) {
         TurtleEggHatchEvent turtleEggHatchEvent = new TurtleEggHatchEvent(this, eggs, newState);
         // TODO Cancelled by default because EntityTurtle doesn't have AI yet, remove it when AI is added
-        turtleEggHatchEvent.setCancelled(true);
-        this.level.getServer().getPluginManager().callEvent(turtleEggHatchEvent);
+        turtleEggHatchEvent.cancel();
+        turtleEggHatchEvent.call();
         int eggsHatching = turtleEggHatchEvent.getEggsHatching();
         if (!turtleEggHatchEvent.isCancelled()) {
             level.addSound(this, Sound.BLOCK_TURTLE_EGG_CRACK);
@@ -267,7 +267,7 @@ public class BlockTurtleEgg extends BlockFlowable {
 
                 CreatureSpawnEvent creatureSpawnEvent = new CreatureSpawnEvent(
                         EntityTurtle.NETWORK_ID, add(0.3 + i * 0.2, 0, 0.3), CreatureSpawnEvent.SpawnReason.TURTLE_EGG);
-                this.level.getServer().getPluginManager().callEvent(creatureSpawnEvent);
+                creatureSpawnEvent.call();
 
                 if (!creatureSpawnEvent.isCancelled()) {
                     EntityTurtle turtle = (EntityTurtle) Entity.createEntity(
@@ -304,17 +304,17 @@ public class BlockTurtleEgg extends BlockFlowable {
                 && !(entity instanceof EntityGhast)
                 && !(entity instanceof EntityPhantom)
                 && entity.getY() >= this.getMaxY()) {
-            Event ev;
 
+            Event event;
             if (entity instanceof Player) {
-                ev = new PlayerInteractEvent((Player) entity, null, this, null, PlayerInteractEvent.Action.PHYSICAL);
+                event = new PlayerInteractEvent((Player) entity, null, this, null, PlayerInteractEvent.Action.PHYSICAL);
             } else {
-                ev = new EntityInteractEvent(entity, this);
+                event = new EntityInteractEvent(entity, this);
             }
 
-            ev.setCancelled(ThreadLocalRandom.current().nextInt(200) > 0);
-            this.level.getServer().getPluginManager().callEvent(ev);
-            if (!ev.isCancelled()) {
+            if (ThreadLocalRandom.current().nextInt(200) > 0) event.cancel();
+            event.call();
+            if (!event.isCancelled()) {
                 this.level.useBreakOn(this, null, null, true);
             }
         }

--- a/src/main/java/cn/nukkit/block/BlockVine.java
+++ b/src/main/java/cn/nukkit/block/BlockVine.java
@@ -314,7 +314,7 @@ public class BlockVine extends BlockTransparentMeta {
         } else {
             event = new BlockGrowEvent(block, vine);
         }
-        this.level.getServer().getPluginManager().callEvent(event);
+        event.call();
         if (!event.isCancelled()) {
             this.level.setBlock(block, vine, true);
         }

--- a/src/main/java/cn/nukkit/block/BlockVinesNether.java
+++ b/src/main/java/cn/nukkit/block/BlockVinesNether.java
@@ -1,6 +1,5 @@
 package cn.nukkit.block;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockproperty.exception.InvalidBlockPropertyMetaException;
@@ -168,10 +167,10 @@ public abstract class BlockVinesNether extends BlockTransparentMeta {
         growing.z = pos.z;
         growing.setVineAge(Math.min(getVineAge() + 1, getMaxVineAge()));
 
-        BlockGrowEvent ev = new BlockGrowEvent(this, growing);
-        Server.getInstance().getPluginManager().callEvent(ev);
+        BlockGrowEvent event = new BlockGrowEvent(this, growing);
+        event.call();
 
-        if (ev.isCancelled()) {
+        if (event.isCancelled()) {
             return false;
         }
 
@@ -210,14 +209,14 @@ public abstract class BlockVinesNether extends BlockTransparentMeta {
             growing.y = pos.y;
             growing.z = pos.z;
 
-            BlockGrowEvent ev = new BlockGrowEvent(this, growing.clone());
-            Server.getInstance().getPluginManager().callEvent(ev);
+            BlockGrowEvent event = new BlockGrowEvent(this, growing.clone());
+            event.call();
 
-            if (ev.isCancelled()) {
+            if (event.isCancelled()) {
                 break;
             }
 
-            if (!level.setBlock(pos, ev.getNewState())) {
+            if (!level.setBlock(pos, event.getNewState())) {
                 break;
             }
 

--- a/src/main/java/cn/nukkit/block/IBlockOreRedstoneGlowing.java
+++ b/src/main/java/cn/nukkit/block/IBlockOreRedstoneGlowing.java
@@ -40,7 +40,7 @@ public interface IBlockOreRedstoneGlowing extends IMutableBlockState {
             Block block = getBlock();
             Level level = getLevel();
             BlockFadeEvent event = new BlockFadeEvent(block, getUnlitState().getBlock());
-            level.getServer().getPluginManager().callEvent(event);
+            event.call();
             if (!event.isCancelled()) {
                 level.setBlock(block, event.getNewState(), false, true);
             }

--- a/src/main/java/cn/nukkit/block/Oxidizable.java
+++ b/src/main/java/cn/nukkit/block/Oxidizable.java
@@ -90,7 +90,7 @@ public interface Oxidizable {
             Block nextBlock = getStateWithOxidizationLevel(OxidizationLevel.values()[oxiLvl + 1])
                     .getBlock(block);
             BlockFadeEvent event = new BlockFadeEvent(block, nextBlock);
-            block.getLevel().getServer().getPluginManager().callEvent(event);
+            event.call();
             if (!event.isCancelled()) {
                 block.getLevel().setBlock(block, event.getNewState());
             }

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityBrewingStand.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityBrewingStand.java
@@ -221,10 +221,10 @@ public class BlockEntityBrewingStand extends BlockEntitySpawnable
         }
 
         if (brewTime == MAX_BREW_TIME) {
-            StartBrewEvent e = new StartBrewEvent(this);
-            this.server.getPluginManager().callEvent(e);
+            StartBrewEvent event = new StartBrewEvent(this);
+            event.call();
 
-            if (e.isCancelled()) {
+            if (event.isCancelled()) {
                 return false;
             }
 
@@ -241,10 +241,10 @@ public class BlockEntityBrewingStand extends BlockEntitySpawnable
         }
 
         // 20 seconds
-        BrewEvent e = new BrewEvent(this);
-        this.server.getPluginManager().callEvent(e);
+        BrewEvent event = new BrewEvent(this);
+        event.call();
 
-        if (e.isCancelled()) {
+        if (event.isCancelled()) {
             stopBrewing();
             return true;
         }

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityCommandBlock.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityCommandBlock.java
@@ -314,7 +314,7 @@ public class BlockEntityCommandBlock extends BlockEntitySpawnable implements ICo
                     } else {
                         this.lastOutput = null;
                         CommandBlockExecuteEvent event = new CommandBlockExecuteEvent(this.getLevelBlock(), cmd);
-                        Server.getInstance().getPluginManager().callEvent(event);
+                        event.call();
                         if (event.isCancelled()) {
                             return false;
                         }

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityConduit.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityConduit.java
@@ -101,10 +101,10 @@ public class BlockEntityConduit extends BlockEntitySpawnable {
             this.spawnToAll();
             if (activeBeforeUpdate && !active) {
                 level.addSound(add(0, 0.5, 0), Sound.CONDUIT_DEACTIVATE);
-                level.getServer().getPluginManager().callEvent(new ConduitDeactivateEvent(getBlock()));
+                new ConduitDeactivateEvent(getBlock()).call();
             } else if (!activeBeforeUpdate && active) {
                 level.addSound(add(0, 0.5, 0), Sound.CONDUIT_ACTIVATE);
-                level.getServer().getPluginManager().callEvent(new ConduitActivateEvent(getBlock()));
+                new ConduitActivateEvent(getBlock()).call();
             }
         }
 

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityFurnace.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityFurnace.java
@@ -261,18 +261,18 @@ public class BlockEntityFurnace extends BlockEntitySpawnable
     }
 
     protected void checkFuel(Item fuel) {
-        FurnaceBurnEvent ev = new FurnaceBurnEvent(this, fuel, fuel.getFuelTime() == null ? 0 : fuel.getFuelTime());
-        this.server.getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        FurnaceBurnEvent event = new FurnaceBurnEvent(this, fuel, fuel.getFuelTime() == null ? 0 : fuel.getFuelTime());
+        event.call();
+        if (event.isCancelled()) {
             return;
         }
 
-        maxTime = (int) Math.ceil(ev.getBurnTime() / (float) getSpeedMultiplier());
-        burnTime = (int) Math.ceil(ev.getBurnTime() / (float) getSpeedMultiplier());
+        maxTime = (int) Math.ceil(event.getBurnTime() / (float) getSpeedMultiplier());
+        burnTime = (int) Math.ceil(event.getBurnTime() / (float) getSpeedMultiplier());
         burnDuration = 0;
         setBurning(true);
 
-        if (burnTime > 0 && ev.isBurning()) {
+        if (burnTime > 0 && event.isBurning()) {
             fuel.setCount(fuel.getCount() - 1);
             if (fuel.getCount() == 0) {
                 if (fuel.getId() == Item.BUCKET && ((ItemBucket) fuel).isLava()) {
@@ -340,16 +340,16 @@ public class BlockEntityFurnace extends BlockEntitySpawnable
                     product = smelt.getResult().clone();
                     product.setCount(count);
 
-                    FurnaceSmeltEvent ev = new FurnaceSmeltEvent(this, raw, product, (float)
+                    FurnaceSmeltEvent event = new FurnaceSmeltEvent(this, raw, product, (float)
                             this.server.getCraftingManager().getRecipeXp(smelt));
-                    this.server.getPluginManager().callEvent(ev);
-                    if (!ev.isCancelled()) {
-                        this.inventory.setResult(ev.getResult());
+                    event.call();
+                    if (!event.isCancelled()) {
+                        this.inventory.setResult(event.getResult());
                         raw.setCount(raw.getCount() - 1);
                         if (raw.getCount() == 0) {
                             raw = new ItemBlock(Block.get(BlockID.AIR), 0, 0);
                         }
-                        this.storedXP += ev.getXp();
+                        this.storedXP += event.getXp();
                         this.inventory.setSmelting(raw);
                     }
 

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityHopper.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityHopper.java
@@ -249,7 +249,7 @@ public class BlockEntityHopper extends BlockEntitySpawnable
         boolean changed = pushItems() || pushItemsIntoMinecart();
 
         HopperSearchItemEvent event = new HopperSearchItemEvent(this, false);
-        this.server.getPluginManager().callEvent(event);
+        event.call();
         if (!event.isCancelled()) {
             if (blockEntity instanceof InventoryHolder || blockSide instanceof BlockComposter) {
                 changed = pullItems(this, this) || changed;
@@ -291,10 +291,10 @@ public class BlockEntityHopper extends BlockEntitySpawnable
                     itemToAdd.count = 1;
                     if (!this.inventory.canAddItem(itemToAdd)) continue;
 
-                    InventoryMoveItemEvent ev = new InventoryMoveItemEvent(
+                    InventoryMoveItemEvent event = new InventoryMoveItemEvent(
                             inv, this.inventory, this, itemToAdd, InventoryMoveItemEvent.Action.SLOT_CHANGE);
-                    this.server.getPluginManager().callEvent(ev);
-                    if (ev.isCancelled()) continue;
+                    event.call();
+                    if (event.isCancelled()) continue;
 
                     Item[] items = this.inventory.addItem(itemToAdd);
                     if (items.length >= 1) continue;
@@ -347,15 +347,15 @@ public class BlockEntityHopper extends BlockEntitySpawnable
 
                     if (!holderInventory.canAddItem(itemToAdd)) continue;
 
-                    InventoryMoveItemEvent ev = new InventoryMoveItemEvent(
+                    InventoryMoveItemEvent event = new InventoryMoveItemEvent(
                             this.inventory,
                             holderInventory,
                             this,
                             itemToAdd,
                             InventoryMoveItemEvent.Action.SLOT_CHANGE);
-                    this.server.getPluginManager().callEvent(ev);
+                    event.call();
 
-                    if (ev.isCancelled()) continue;
+                    if (event.isCancelled()) continue;
 
                     Item[] items = holderInventory.addItem(itemToAdd);
 
@@ -422,7 +422,7 @@ public class BlockEntityHopper extends BlockEntitySpawnable
                                     this,
                                     itemToAdd,
                                     InventoryMoveItemEvent.Action.SLOT_CHANGE);
-                            this.server.getPluginManager().callEvent(event);
+                            event.call();
 
                             if (!event.isCancelled()) {
                                 inventory.setSmelting(itemToAdd);
@@ -439,7 +439,7 @@ public class BlockEntityHopper extends BlockEntitySpawnable
                                     this,
                                     itemToAdd,
                                     InventoryMoveItemEvent.Action.SLOT_CHANGE);
-                            this.server.getPluginManager().callEvent(event);
+                            event.call();
 
                             if (!event.isCancelled()) {
                                 smelting.count++;
@@ -457,7 +457,7 @@ public class BlockEntityHopper extends BlockEntitySpawnable
                                     this,
                                     itemToAdd,
                                     InventoryMoveItemEvent.Action.SLOT_CHANGE);
-                            this.server.getPluginManager().callEvent(event);
+                            event.call();
 
                             if (!event.isCancelled()) {
                                 inventory.setFuel(itemToAdd);
@@ -474,7 +474,7 @@ public class BlockEntityHopper extends BlockEntitySpawnable
                                     this,
                                     itemToAdd,
                                     InventoryMoveItemEvent.Action.SLOT_CHANGE);
-                            this.server.getPluginManager().callEvent(event);
+                            event.call();
 
                             if (!event.isCancelled()) {
                                 fuel.count++;
@@ -535,11 +535,11 @@ public class BlockEntityHopper extends BlockEntitySpawnable
                         continue;
                     }
 
-                    InventoryMoveItemEvent ev = new InventoryMoveItemEvent(
+                    InventoryMoveItemEvent event1 = new InventoryMoveItemEvent(
                             this.inventory, inventory, this, itemToAdd, InventoryMoveItemEvent.Action.SLOT_CHANGE);
-                    this.server.getPluginManager().callEvent(ev);
+                    event1.call();
 
-                    if (ev.isCancelled()) {
+                    if (event1.isCancelled()) {
                         continue;
                     }
 

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityItemFrame.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityItemFrame.java
@@ -155,7 +155,7 @@ public class BlockEntityItemFrame extends BlockEntitySpawnable {
         }
 
         ItemFrameDropItemEvent event = new ItemFrameDropItemEvent(player, getLevelBlock(), this, drop);
-        level.getServer().getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) {
             if (player != null) {
                 spawnTo(player);

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityPistonArm.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityPistonArm.java
@@ -88,7 +88,7 @@ public class BlockEntityPistonArm extends BlockEntitySpawnable {
         // 玩家客户端会自动处理移动
         if (diff == 0 || !entity.canBePushed() || entity instanceof Player) return;
         EntityMoveByPistonEvent event = new EntityMoveByPistonEvent(entity, entity.getPosition());
-        this.level.getServer().getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) return;
         entity.onPushByPiston(this);
         if (entity.closed) return;

--- a/src/main/java/cn/nukkit/blockentity/BlockEntitySign.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntitySign.java
@@ -261,7 +261,7 @@ public class BlockEntitySign extends BlockEntitySpawnable {
 
         if (!this.namedTag.contains(TAG_LOCKED_FOR_EDITING_BY)
                 || !Objects.equals(player.getId(), this.getEditorEntityRuntimeId())) {
-            signChangeEvent.setCancelled();
+            signChangeEvent.cancel();
         }
 
         if (player.getRemoveFormat()) {
@@ -270,7 +270,7 @@ public class BlockEntitySign extends BlockEntitySpawnable {
             }
         }
 
-        this.server.getPluginManager().callEvent(signChangeEvent);
+        signChangeEvent.call();
 
         if (!signChangeEvent.isCancelled() && player.isOpenSignFront() != null) {
             this.setText(player.isOpenSignFront(), signChangeEvent.getLines());

--- a/src/main/java/cn/nukkit/command/ConsoleCommandSender.java
+++ b/src/main/java/cn/nukkit/command/ConsoleCommandSender.java
@@ -109,7 +109,7 @@ public class ConsoleCommandSender implements CommandSender {
                         .getLanguage()
                         .tr(new TranslationContainer(msg.getMessageId(), msg.getParameters()));
                 ConsoleCommandOutputEvent event = new ConsoleCommandOutputEvent(this, text);
-                this.getServer().getPluginManager().callEvent(event);
+                event.call();
                 if (event.isCancelled()) continue;
                 text = event.getMessage();
                 this.sendMessage(text);

--- a/src/main/java/cn/nukkit/console/NukkitConsole.java
+++ b/src/main/java/cn/nukkit/console/NukkitConsole.java
@@ -26,9 +26,8 @@ public class NukkitConsole extends SimpleTerminalConsole {
     protected void runCommand(String command) {
         if (executingCommands.get()) {
             ServerCommandEvent event = new ServerCommandEvent(server.getConsoleSender(), command);
-            if (server.getPluginManager() != null) {
-                server.getPluginManager().callEvent(event);
-            }
+            event.call();
+
             if (!event.isCancelled()) {
                 Server.getInstance()
                         .getScheduler()

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -1435,8 +1435,7 @@ public abstract class Entity extends Location implements Metadatable {
             this.lastUpdate = this.server.getTick();
 
             EntitySpawnEvent event = new EntitySpawnEvent(this);
-
-            this.server.getPluginManager().callEvent(event);
+            event.call();
 
             if (event.isCancelled()) {
                 this.close(false);
@@ -1965,7 +1964,7 @@ public abstract class Entity extends Location implements Metadatable {
                 && source.getCause() == DamageCause.FALL) return false;
 
         // 事件回调函数
-        getServer().getPluginManager().callEvent(source);
+        source.call();
         if (source.isCancelled()) {
             return false;
         }
@@ -2031,7 +2030,7 @@ public abstract class Entity extends Location implements Metadatable {
                         player.getInventory().clear(player.getInventory().getHeldItemIndex(), true);
                     }
 
-                    source.setCancelled(true);
+                    source.cancel();
                     return false;
                 }
             }
@@ -2062,7 +2061,7 @@ public abstract class Entity extends Location implements Metadatable {
     }
 
     public void heal(EntityRegainHealthEvent source) {
-        this.server.getPluginManager().callEvent(source);
+        source.call();
         if (source.isCancelled()) {
             return;
         }
@@ -2312,10 +2311,10 @@ public abstract class Entity extends Location implements Metadatable {
         }
 
         if (this.inPortalTicks == 80) {
-            EntityPortalEnterEvent ev = new EntityPortalEnterEvent(this, PortalType.NETHER);
-            getServer().getPluginManager().callEvent(ev);
+            EntityPortalEnterEvent event = new EntityPortalEnterEvent(this, PortalType.NETHER);
+            event.call();
 
-            if (!ev.isCancelled()
+            if (!event.isCancelled()
                     && (level.getDimension() == Level.DIMENSION_OVERWORLD
                             || level.getDimension() == Level.DIMENSION_NETHER)) {
                 Position newPos = EnumLevel.convertPosBetweenNetherAndOverworld(this);
@@ -2608,9 +2607,9 @@ public abstract class Entity extends Location implements Metadatable {
         }
 
         // Entity entering a vehicle
-        EntityVehicleEnterEvent ev = new EntityVehicleEnterEvent(entity, this);
-        server.getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        EntityVehicleEnterEvent event = new EntityVehicleEnterEvent(entity, this);
+        event.call();
+        if (event.isCancelled()) {
             return false;
         }
 
@@ -2632,9 +2631,9 @@ public abstract class Entity extends Location implements Metadatable {
 
     public boolean dismountEntity(Entity entity, boolean sendLinks) {
         // Run the events
-        EntityVehicleExitEvent ev = new EntityVehicleExitEvent(entity, this);
-        server.getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        EntityVehicleExitEvent event = new EntityVehicleExitEvent(entity, this);
+        event.call();
+        if (event.isCancelled()) {
             int seatIndex = this.passengers.indexOf(entity);
             if (seatIndex == 0) {
                 this.broadcastLinkPacket(entity, TYPE_RIDE);
@@ -2801,7 +2800,7 @@ public abstract class Entity extends Location implements Metadatable {
         Block down = this.level.getBlock(floorLocation.down());
 
         EntityFallEvent event = new EntityFallEvent(this, down, fallDistance);
-        this.server.getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) {
             return;
         }
@@ -2832,8 +2831,8 @@ public abstract class Entity extends Location implements Metadatable {
                 if (onPhysicalInteraction(down, false)) {
                     return;
                 }
-                var farmEvent = new FarmLandDecayEvent(this, down);
-                this.server.getPluginManager().callEvent(farmEvent);
+                FarmLandDecayEvent farmEvent = new FarmLandDecayEvent(this, down);
+                farmEvent.call();
                 if (farmEvent.isCancelled()) return;
                 this.level.setBlock(down, new BlockDirt(), false, true);
                 return;
@@ -2852,18 +2851,18 @@ public abstract class Entity extends Location implements Metadatable {
 
     @PowerNukkitXDifference(info = "change to protected")
     protected boolean onPhysicalInteraction(Block block, boolean cancelled) {
-        Event ev;
+        Event event;
 
         if (this instanceof Player) {
-            ev = new PlayerInteractEvent((Player) this, null, block, null, Action.PHYSICAL);
+            event = new PlayerInteractEvent((Player) this, null, block, null, Action.PHYSICAL);
         } else {
-            ev = new EntityInteractEvent(this, block);
+            event = new EntityInteractEvent(this, block);
         }
 
-        ev.setCancelled(cancelled);
+        if (cancelled) event.cancel();
 
-        this.server.getPluginManager().callEvent(ev);
-        return ev.isCancelled();
+        event.call();
+        return event.isCancelled();
     }
 
     public void handleLavaMovement() {
@@ -2945,9 +2944,9 @@ public abstract class Entity extends Location implements Metadatable {
         }
 
         if (this.isValid()) {
-            EntityLevelChangeEvent ev = new EntityLevelChangeEvent(this, this.level, targetLevel);
-            this.server.getPluginManager().callEvent(ev);
-            if (ev.isCancelled()) {
+            EntityLevelChangeEvent event = new EntityLevelChangeEvent(this, this.level, targetLevel);
+            event.call();
+            if (event.isCancelled()) {
                 return false;
             }
 
@@ -3379,10 +3378,10 @@ public abstract class Entity extends Location implements Metadatable {
                 if (this.getRiding() == null
                         && this.getPassengers().isEmpty()
                         && !(this instanceof EntityEnderDragon)) {
-                    EntityPortalEnterEvent ev = new EntityPortalEnterEvent(this, PortalType.END);
-                    getServer().getPluginManager().callEvent(ev);
+                    EntityPortalEnterEvent event = new EntityPortalEnterEvent(this, PortalType.END);
+                    event.call();
 
-                    if (!ev.isCancelled()
+                    if (!event.isCancelled()
                             && (level == EnumLevel.OVERWORLD.getLevel() || level == EnumLevel.THE_END.getLevel())) {
                         final Position newPos = EnumLevel.moveToTheEnd(this);
                         if (newPos != null) {
@@ -3577,9 +3576,9 @@ public abstract class Entity extends Location implements Metadatable {
      */
     public boolean setMotion(Vector3 motion) {
         if (!this.justCreated) {
-            EntityMotionEvent ev = new EntityMotionEvent(this, motion);
-            this.server.getPluginManager().callEvent(ev);
-            if (ev.isCancelled()) {
+            EntityMotionEvent event = new EntityMotionEvent(this, motion);
+            event.call();
+            if (event.isCancelled()) {
                 return false;
             }
         }
@@ -3635,12 +3634,12 @@ public abstract class Entity extends Location implements Metadatable {
         Location from = this.getLocation();
         Location to = location;
         if (cause != null) {
-            EntityTeleportEvent ev = new EntityTeleportEvent(this, from, to, cause);
-            this.server.getPluginManager().callEvent(ev);
-            if (ev.isCancelled()) {
+            EntityTeleportEvent event = new EntityTeleportEvent(this, from, to, cause);
+            event.call();
+            if (event.isCancelled()) {
                 return false;
             }
-            to = ev.getTo();
+            to = event.getTo();
         }
 
         final Entity currentRide = getRiding();
@@ -3713,8 +3712,7 @@ public abstract class Entity extends Location implements Metadatable {
             if (despawn) {
                 try {
                     EntityDespawnEvent event = new EntityDespawnEvent(this);
-
-                    this.server.getPluginManager().callEvent(event);
+                    event.call();
 
                     if (event.isCancelled()) {
                         this.closed = false;

--- a/src/main/java/cn/nukkit/entity/EntityHuman.java
+++ b/src/main/java/cn/nukkit/entity/EntityHuman.java
@@ -138,7 +138,7 @@ public class EntityHuman extends EntityHumanType {
             }
             this.addFreezingTicks(1);
             EntityFreezeEvent event = new EntityFreezeEvent(this);
-            this.server.getPluginManager().callEvent(event);
+            event.call();
             if (!event.isCancelled()) {
                 this.setMovementSpeed((float) Math.max(0.05, getMovementSpeed() - 3.58e-4));
             }

--- a/src/main/java/cn/nukkit/entity/EntityLiving.java
+++ b/src/main/java/cn/nukkit/entity/EntityLiving.java
@@ -197,15 +197,15 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
             return;
         }
         super.kill();
-        EntityDeathEvent ev = new EntityDeathEvent(this, this.getDrops());
-        this.server.getPluginManager().callEvent(ev);
+        EntityDeathEvent event = new EntityDeathEvent(this, this.getDrops());
+        event.call();
 
         var manager = this.server.getScoreboardManager();
         // 测试环境中此项会null，所以说需要判空下
         if (manager != null) manager.onEntityDead(this);
 
         if (this.level.getGameRules().getBoolean(GameRule.DO_ENTITY_DROPS)) {
-            for (cn.nukkit.item.Item item : ev.getDrops()) {
+            for (cn.nukkit.item.Item item : event.getDrops()) {
                 this.getLevel().dropItem(this, item);
             }
         }
@@ -443,10 +443,10 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
         boolean knockBack = !(damager instanceof EntityProjectile);
         EntityDamageBlockedEvent event = new EntityDamageBlockedEvent(this, source, knockBack, true);
         if (!blocked || !source.canBeReducedByArmor()) {
-            event.setCancelled();
+            event.cancel();
         }
 
-        getServer().getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) {
             return false;
         }

--- a/src/main/java/cn/nukkit/entity/EntityPhysical.java
+++ b/src/main/java/cn/nukkit/entity/EntityPhysical.java
@@ -102,7 +102,7 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
         if (this.getFreezingTicks() < 140 && collidedWithPowderSnow) {
             this.addFreezingTicks(1);
             EntityFreezeEvent event = new EntityFreezeEvent(this);
-            this.server.getPluginManager().callEvent(event);
+            event.call();
             if (!event.isCancelled()) {
                 // this.setMovementSpeed(); //todo 给物理实体添加freeze减速
             }

--- a/src/main/java/cn/nukkit/entity/ai/executor/EntityExplosionExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/EntityExplosionExecutor.java
@@ -3,7 +3,6 @@ package cn.nukkit.entity.ai.executor;
 import static cn.nukkit.entity.Entity.DATA_FLAGS;
 import static cn.nukkit.entity.Entity.DATA_FLAG_IGNITED;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.entity.Entity;
@@ -70,22 +69,22 @@ public class EntityExplosionExecutor implements IBehaviorExecutor {
     }
 
     protected void explode(EntityIntelligent entity) {
-        EntityExplosionPrimeEvent ev = new EntityExplosionPrimeEvent(
+        EntityExplosionPrimeEvent event = new EntityExplosionPrimeEvent(
                 entity,
                 entity instanceof EntityCreeper creeper
                         ? creeper.isPowered() ? explodeForce * 2 : explodeForce
                         : explodeForce);
 
         if (!entity.level.gameRules.getBoolean(GameRule.MOB_GRIEFING)) {
-            ev.setBlockBreaking(false);
+            event.setBlockBreaking(false);
         }
 
-        Server.getInstance().getPluginManager().callEvent(ev);
+        event.call();
 
-        if (!ev.isCancelled()) {
-            Explosion explosion = new Explosion(entity, (float) ev.getForce(), entity);
+        if (!event.isCancelled()) {
+            Explosion explosion = new Explosion(entity, (float) event.getForce(), entity);
 
-            if (ev.isBlockBreaking() && entity.level.getGameRules().getBoolean(GameRule.MOB_GRIEFING)) {
+            if (event.isBlockBreaking() && entity.level.getGameRules().getBoolean(GameRule.MOB_GRIEFING)) {
                 explosion.explodeA();
             }
 

--- a/src/main/java/cn/nukkit/entity/ai/executor/ShootExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/ShootExecutor.java
@@ -1,6 +1,5 @@
 package cn.nukkit.entity.ai.executor;
 
-import cn.nukkit.Server;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.entity.EntityIntelligent;
 import cn.nukkit.entity.EntityLiving;
@@ -195,7 +194,7 @@ public class ShootExecutor implements EntityControl, IBehaviorExecutor {
         }
 
         EntityShootBowEvent entityShootBowEvent = new EntityShootBowEvent(entity, bow, arrow, f);
-        Server.getInstance().getPluginManager().callEvent(entityShootBowEvent);
+        entityShootBowEvent.call();
         if (entityShootBowEvent.isCancelled()) {
             entityShootBowEvent.getProjectile().kill();
         } else {
@@ -217,10 +216,10 @@ public class ShootExecutor implements EntityControl, IBehaviorExecutor {
             }
 
             if (entityShootBowEvent.getProjectile() != null) {
-                ProjectileLaunchEvent projectev =
+                ProjectileLaunchEvent projectileLaunchEvent =
                         new ProjectileLaunchEvent(entityShootBowEvent.getProjectile(), entity);
-                Server.getInstance().getPluginManager().callEvent(projectev);
-                if (projectev.isCancelled()) {
+                projectileLaunchEvent.call();
+                if (projectileLaunchEvent.isCancelled()) {
                     entityShootBowEvent.getProjectile().kill();
                 } else {
                     entityShootBowEvent.getProjectile().spawnToAll();

--- a/src/main/java/cn/nukkit/entity/item/EntityArmorStand.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityArmorStand.java
@@ -217,18 +217,18 @@ public class EntityArmorStand extends Entity implements EntityInventoryHolder, E
             }
         }
 
-        var ev = new PlayerChangeArmorStandEvent(player, this, item, slot);
-        this.getServer().getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) return false;
+        PlayerChangeArmorStandEvent event = new PlayerChangeArmorStandEvent(player, this, item, slot);
+        event.call();
+        if (event.isCancelled()) return false;
 
         boolean changed = false;
         if (isArmor) {
-            changed = this.tryChangeEquipment(player, ev.getItem(), slot, true);
+            changed = this.tryChangeEquipment(player, event.getItem(), slot, true);
             slot = EntityEquipmentInventory.MAIN_HAND;
         }
 
         if (!changed) {
-            changed = this.tryChangeEquipment(player, ev.getItem(), slot, false);
+            changed = this.tryChangeEquipment(player, event.getItem(), slot, false);
         }
 
         if (changed) {
@@ -402,7 +402,7 @@ public class EntityArmorStand extends Entity implements EntityInventoryHolder, E
 
         switch (source.getCause()) {
             case FALL:
-                source.setCancelled(true);
+                source.cancel();
                 level.addSound(this, Sound.MOB_ARMOR_STAND_LAND);
                 break;
             case CONTACT:
@@ -411,7 +411,7 @@ public class EntityArmorStand extends Entity implements EntityInventoryHolder, E
             case DROWNING:
             case SUFFOCATION:
             case PROJECTILE:
-                source.setCancelled(true);
+                source.cancel();
                 break;
             case FIRE:
             case FIRE_TICK:
@@ -424,7 +424,7 @@ public class EntityArmorStand extends Entity implements EntityInventoryHolder, E
 
         if (source.getCause() != EntityDamageEvent.DamageCause.ENTITY_ATTACK) {
             if (namedTag.getByte("InvulnerableTimer") > 0) {
-                source.setCancelled(true);
+                source.cancel();
             }
             if (super.attack(source)) {
                 namedTag.putByte("InvulnerableTimer", 9);
@@ -433,7 +433,7 @@ public class EntityArmorStand extends Entity implements EntityInventoryHolder, E
             return false;
         }
 
-        getServer().getPluginManager().callEvent(source);
+        source.call();
         if (source.isCancelled()) {
             return false;
         }

--- a/src/main/java/cn/nukkit/entity/item/EntityBoat.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityBoat.java
@@ -279,7 +279,7 @@ public class EntityBoat extends EntityVehicle {
                 }
             }
         }
-        this.getServer().getPluginManager().callEvent(new VehicleUpdateEvent(this));
+        new VehicleUpdateEvent(this).call();
         return hasUpdated;
     }
 
@@ -320,7 +320,7 @@ public class EntityBoat extends EntityVehicle {
         Location to = new Location(this.x, this.y, this.z, this.yaw, this.pitch, level);
 
         if (!from.equals(to)) {
-            this.getServer().getPluginManager().callEvent(new VehicleMoveEvent(this, from, to));
+            new VehicleMoveEvent(this, from, to).call();
         }
 
         // TODO: lily pad collision

--- a/src/main/java/cn/nukkit/entity/item/EntityFallingBlock.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityFallingBlock.java
@@ -166,25 +166,25 @@ public class EntityFallingBlock extends Entity {
                     if (mergedHeight > 8) {
                         EntityBlockChangeEvent event =
                                 new EntityBlockChangeEvent(this, floorBlock, Block.get(Block.SNOW_LAYER, 0x7));
-                        this.server.getPluginManager().callEvent(event);
+                        event.call();
                         if (!event.isCancelled()) {
                             this.level.setBlock(floorPos, event.getTo(), true);
 
                             Vector3 abovePos = floorPos.up();
                             Block aboveBlock = this.level.getBlock(abovePos);
                             if (aboveBlock.getId() == Block.AIR) {
-                                EntityBlockChangeEvent event2 = new EntityBlockChangeEvent(
+                                EntityBlockChangeEvent event1 = new EntityBlockChangeEvent(
                                         this, aboveBlock, Block.get(Block.SNOW_LAYER, mergedHeight - 8 - 1));
-                                this.server.getPluginManager().callEvent(event2);
-                                if (!event2.isCancelled()) {
-                                    this.level.setBlock(abovePos, event2.getTo(), true);
+                                event1.call();
+                                if (!event1.isCancelled()) {
+                                    this.level.setBlock(abovePos, event1.getTo(), true);
                                 }
                             }
                         }
                     } else {
                         EntityBlockChangeEvent event = new EntityBlockChangeEvent(
                                 this, floorBlock, Block.get(Block.SNOW_LAYER, mergedHeight - 1));
-                        this.server.getPluginManager().callEvent(event);
+                        event.call();
                         if (!event.isCancelled()) {
                             this.level.setBlock(floorPos, event.getTo(), true);
                         }
@@ -199,7 +199,7 @@ public class EntityFallingBlock extends Entity {
                 } else {
                     EntityBlockChangeEvent event =
                             new EntityBlockChangeEvent(this, block, Block.get(getBlock(), getDamage()));
-                    server.getPluginManager().callEvent(event);
+                    event.call();
                     if (!event.isCancelled()) {
                         if (!breakOnGround) getLevel().setBlock(pos, event.getTo(), true);
                         else {

--- a/src/main/java/cn/nukkit/entity/item/EntityFishingHook.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityFishingHook.java
@@ -249,7 +249,7 @@ public class EntityFishingHook extends SlenderProjectile {
             motion.y += Math.sqrt(player.distance(pos)) * 0.08;
 
             PlayerFishEvent event = new PlayerFishEvent(player, this, item, experience, motion);
-            this.getServer().getPluginManager().callEvent(event);
+            event.call();
 
             if (!event.isCancelled()) {
                 EntityItem itemEntity = (EntityItem) Entity.createEntity(
@@ -306,7 +306,7 @@ public class EntityFishingHook extends SlenderProjectile {
 
     @Override
     public void onCollideWithEntity(Entity entity) {
-        this.server.getPluginManager().callEvent(new ProjectileHitEvent(this, MovingObjectPosition.fromEntity(entity)));
+        new ProjectileHitEvent(this, MovingObjectPosition.fromEntity(entity)).call();
         float damage = this.getResultDamage();
 
         EntityDamageEvent ev;

--- a/src/main/java/cn/nukkit/entity/item/EntityItem.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityItem.java
@@ -109,7 +109,7 @@ public class EntityItem extends Entity {
             this.fireProof = true; // Netherite items are fireproof
         }
 
-        this.server.getPluginManager().callEvent(new ItemSpawnEvent(this));
+        new ItemSpawnEvent(this).call();
     }
 
     @PowerNukkitDifference(since = "1.4.0.0-PN", info = "Netherite stuff is immune to fire and lava damage")
@@ -254,9 +254,9 @@ public class EntityItem extends Entity {
             this.updateMovement();
 
             if (this.age > 6000) {
-                ItemDespawnEvent ev = new ItemDespawnEvent(this);
-                this.server.getPluginManager().callEvent(ev);
-                if (ev.isCancelled()) {
+                ItemDespawnEvent event = new ItemDespawnEvent(this);
+                event.call();
+                if (event.isCancelled()) {
                     this.age = 0;
                 } else {
                     this.kill();

--- a/src/main/java/cn/nukkit/entity/item/EntityMinecartAbstract.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityMinecartAbstract.java
@@ -191,10 +191,10 @@ public abstract class EntityMinecartAbstract extends EntityVehicle {
             Location from = new Location(lastX, lastY, lastZ, lastYaw, lastPitch, level);
             Location to = new Location(this.x, this.y, this.z, this.yaw, this.pitch, level);
 
-            this.getServer().getPluginManager().callEvent(new VehicleUpdateEvent(this));
+            new VehicleUpdateEvent(this).call();
 
             if (!from.equals(to)) {
-                this.getServer().getPluginManager().callEvent(new VehicleMoveEvent(this, from, to));
+                new VehicleMoveEvent(this, from, to).call();
             }
 
             // Collisions

--- a/src/main/java/cn/nukkit/entity/item/EntityMinecartHopper.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityMinecartHopper.java
@@ -55,7 +55,7 @@ public class EntityMinecartHopper extends EntityMinecartAbstract implements Inve
         }
 
         HopperSearchItemEvent event = new HopperSearchItemEvent(this, true);
-        this.server.getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) return false;
 
         this.updatePickupArea();

--- a/src/main/java/cn/nukkit/entity/item/EntityMinecartTNT.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityMinecartTNT.java
@@ -98,7 +98,7 @@ public class EntityMinecartTNT extends EntityMinecartAbstract implements EntityE
 
         EntityExplosionPrimeEvent event = new EntityExplosionPrimeEvent(
                 this, (4.0D + ThreadLocalRandom.current().nextDouble() * 1.5D * root));
-        server.getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) {
             return;
         }

--- a/src/main/java/cn/nukkit/entity/item/EntityPotion.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityPotion.java
@@ -94,7 +94,7 @@ public class EntityPotion extends EntityProjectile {
     protected void splash(Entity collidedWith) {
         Potion potion = Potion.getPotion(this.potionId);
         PotionCollideEvent event = new PotionCollideEvent(potion, this);
-        this.server.getPluginManager().callEvent(event);
+        event.call();
 
         if (event.isCancelled()) {
             return;

--- a/src/main/java/cn/nukkit/entity/item/EntityPrimedTNT.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityPrimedTNT.java
@@ -167,7 +167,7 @@ public class EntityPrimedTNT extends Entity implements EntityExplosive {
     @Override
     public void explode() {
         EntityExplosionPrimeEvent event = new EntityExplosionPrimeEvent(this, 4);
-        server.getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) {
             return;
         }

--- a/src/main/java/cn/nukkit/entity/item/EntityVehicle.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityVehicle.java
@@ -105,19 +105,17 @@ public abstract class EntityVehicle extends Entity implements EntityRideable, En
         if (source instanceof EntityDamageByEntityEvent) {
             final Entity damagingEntity = ((EntityDamageByEntityEvent) source).getDamager();
 
-            final VehicleDamageByEntityEvent byEvent =
+            final VehicleDamageByEntityEvent entityEvent =
                     new VehicleDamageByEntityEvent(this, damagingEntity, source.getFinalDamage());
+            entityEvent.call();
 
-            getServer().getPluginManager().callEvent(byEvent);
-
-            if (byEvent.isCancelled()) return false;
+            if (entityEvent.isCancelled()) return false;
 
             instantKill = damagingEntity instanceof Player && ((Player) damagingEntity).isCreative();
         } else {
 
             final VehicleDamageEvent damageEvent = new VehicleDamageEvent(this, source.getFinalDamage());
-
-            getServer().getPluginManager().callEvent(damageEvent);
+            damageEvent.call();
 
             if (damageEvent.isCancelled()) return false;
         }
@@ -125,17 +123,15 @@ public abstract class EntityVehicle extends Entity implements EntityRideable, En
         if (instantKill || getHealth() - source.getFinalDamage() < 1) {
             if (source instanceof EntityDamageByEntityEvent) {
                 final Entity damagingEntity = ((EntityDamageByEntityEvent) source).getDamager();
-                final VehicleDestroyByEntityEvent byDestroyEvent =
+                final VehicleDestroyByEntityEvent destroyByEntityEvent =
                         new VehicleDestroyByEntityEvent(this, damagingEntity);
 
-                getServer().getPluginManager().callEvent(byDestroyEvent);
+                destroyByEntityEvent.call();
 
-                if (byDestroyEvent.isCancelled()) return false;
+                if (destroyByEntityEvent.isCancelled()) return false;
             } else {
-
                 final VehicleDestroyEvent destroyEvent = new VehicleDestroyEvent(this);
-
-                getServer().getPluginManager().callEvent(destroyEvent);
+                destroyEvent.call();
 
                 if (destroyEvent.isCancelled()) return false;
             }

--- a/src/main/java/cn/nukkit/entity/mob/EntityCreeper.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityCreeper.java
@@ -134,21 +134,21 @@ public class EntityCreeper extends EntityMob implements EntityWalkable, EntityIn
     }
 
     public void setPowered(EntityLightningStrike bolt) {
-        CreeperPowerEvent ev = new CreeperPowerEvent(this, bolt, CreeperPowerEvent.PowerCause.LIGHTNING);
-        this.getServer().getPluginManager().callEvent(ev);
+        CreeperPowerEvent event = new CreeperPowerEvent(this, bolt, CreeperPowerEvent.PowerCause.LIGHTNING);
+        event.call();
 
-        if (!ev.isCancelled()) {
+        if (!event.isCancelled()) {
             this.setDataProperty(new ByteEntityData(DATA_POWERED, 1));
             this.namedTag.putBoolean("powered", true);
         }
     }
 
     public void setPowered(boolean powered) {
-        CreeperPowerEvent ev = new CreeperPowerEvent(
+        CreeperPowerEvent event = new CreeperPowerEvent(
                 this, powered ? CreeperPowerEvent.PowerCause.SET_ON : CreeperPowerEvent.PowerCause.SET_OFF);
-        this.getServer().getPluginManager().callEvent(ev);
+        event.call();
 
-        if (!ev.isCancelled()) {
+        if (!event.isCancelled()) {
             this.setDataProperty(new ByteEntityData(DATA_POWERED, powered ? 1 : 0));
             this.namedTag.putBoolean("powered", powered);
         }

--- a/src/main/java/cn/nukkit/entity/passive/EntityHorse.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityHorse.java
@@ -309,7 +309,7 @@ public class EntityHorse extends EntityAnimal
         Block down = this.level.getBlock(floorLocation.down());
 
         EntityFallEvent event = new EntityFallEvent(this, down, fallDistance);
-        this.server.getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) {
             return;
         }
@@ -333,8 +333,8 @@ public class EntityHorse extends EntityAnimal
                 if (onPhysicalInteraction(down, false)) {
                     return;
                 }
-                var farmEvent = new FarmLandDecayEvent(this, down);
-                this.server.getPluginManager().callEvent(farmEvent);
+                FarmLandDecayEvent farmEvent = new FarmLandDecayEvent(this, down);
+                farmEvent.call();
                 if (farmEvent.isCancelled()) return;
                 this.level.setBlock(down, new BlockDirt(), false, true);
                 return;

--- a/src/main/java/cn/nukkit/entity/projectile/EntityProjectile.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityProjectile.java
@@ -99,7 +99,7 @@ public abstract class EntityProjectile extends Entity {
 
     public void onCollideWithEntity(Entity entity) {
         ProjectileHitEvent projectileHitEvent = new ProjectileHitEvent(this, MovingObjectPosition.fromEntity(entity));
-        this.server.getPluginManager().callEvent(projectileHitEvent);
+        projectileHitEvent.call();
 
         if (projectileHitEvent.isCancelled()) {
             return;
@@ -123,7 +123,7 @@ public abstract class EntityProjectile extends Entity {
 
             if (this.fireTicks > 0) {
                 EntityCombustByEntityEvent event = new EntityCombustByEntityEvent(this, entity, 5);
-                this.server.getPluginManager().callEvent(event);
+                event.call();
                 if (!event.isCancelled()) {
                     entity.setOnFire(event.getDuration());
                 }
@@ -258,12 +258,11 @@ public abstract class EntityProjectile extends Entity {
                 this.motionY = 0;
                 this.motionZ = 0;
 
-                this.server
-                        .getPluginManager()
-                        .callEvent(new ProjectileHitEvent(
-                                this,
-                                MovingObjectPosition.fromBlock(
-                                        this.getFloorX(), this.getFloorY(), this.getFloorZ(), -1, this)));
+                ProjectileHitEvent event = new ProjectileHitEvent(
+                        this,
+                        MovingObjectPosition.fromBlock(this.getFloorX(), this.getFloorY(), this.getFloorZ(), -1, this));
+                event.call();
+
                 onCollideWithBlock(position, motion);
                 addHitEffect();
                 return false;

--- a/src/main/java/cn/nukkit/entity/projectile/EntitySmallFireBall.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntitySmallFireBall.java
@@ -73,7 +73,7 @@ public class EntitySmallFireBall extends EntityProjectile {
 
     public void onCollideWithEntity(Entity entity) {
         ProjectileHitEvent projectileHitEvent = new ProjectileHitEvent(this, MovingObjectPosition.fromEntity(entity));
-        this.server.getPluginManager().callEvent(projectileHitEvent);
+        projectileHitEvent.call();
         if (projectileHitEvent.isCancelled()) return;
         this.level
                 .getVibrationManager()
@@ -85,7 +85,7 @@ public class EntitySmallFireBall extends EntityProjectile {
             addHitEffect();
             this.hadCollision = true;
             EntityCombustByEntityEvent event = new EntityCombustByEntityEvent(this, entity, 5);
-            this.server.getPluginManager().callEvent(event);
+            event.call();
             if (!event.isCancelled()) entity.setOnFire(event.getDuration());
         }
         afterCollisionWithEntity(entity);
@@ -110,10 +110,10 @@ public class EntitySmallFireBall extends EntityProjectile {
             fire.level = level;
 
             if (fire.isBlockTopFacingSurfaceSolid(fire.down()) || fire.canNeighborBurn()) {
-                BlockIgniteEvent e = new BlockIgniteEvent(
+                BlockIgniteEvent event = new BlockIgniteEvent(
                         this.getLevelBlock(), null, null, BlockIgniteEvent.BlockIgniteCause.FIREBALL);
-                level.getServer().getPluginManager().callEvent(e);
-                if (!e.isCancelled()) {
+                event.call();
+                if (!event.isCancelled()) {
                     level.setBlock(fire, fire, true);
                 }
             }

--- a/src/main/java/cn/nukkit/entity/projectile/EntityThrownTrident.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityThrownTrident.java
@@ -291,7 +291,7 @@ public class EntityThrownTrident extends SlenderProjectile {
             return;
         }
 
-        this.server.getPluginManager().callEvent(new ProjectileHitEvent(this, MovingObjectPosition.fromEntity(entity)));
+        new ProjectileHitEvent(this, MovingObjectPosition.fromEntity(entity)).call();
         float damage = this.getResultDamage();
         if (this.impalingLevel > 0
                 && (entity.isTouchingWater()

--- a/src/main/java/cn/nukkit/entity/projectile/SlenderProjectile.java
+++ b/src/main/java/cn/nukkit/entity/projectile/SlenderProjectile.java
@@ -181,12 +181,11 @@ public abstract class SlenderProjectile extends EntityProjectile {
             if (block.getId() == 0 && collisionBlock != null) {
                 block = collisionBlock;
             }
-            this.server
-                    .getPluginManager()
-                    .callEvent(new ProjectileHitEvent(
-                            this,
-                            lastHitBlock = MovingObjectPosition.fromBlock(
-                                    block.getFloorX(), block.getFloorY(), block.getFloorZ(), blockFace, this)));
+            ProjectileHitEvent event = new ProjectileHitEvent(
+                    this,
+                    lastHitBlock = MovingObjectPosition.fromBlock(
+                            block.getFloorX(), block.getFloorY(), block.getFloorZ(), blockFace, this));
+            event.call();
             onCollideWithBlock(getPosition(), getMotion());
             addHitEffect();
         }

--- a/src/main/java/cn/nukkit/entity/weather/EntityLightning.java
+++ b/src/main/java/cn/nukkit/entity/weather/EntityLightning.java
@@ -71,11 +71,11 @@ public class EntityLightning extends Entity implements EntityLightningStrike {
                 //                this.getLevel().setBlock(fire, fire, true); WTF???
                 if (fire.isBlockTopFacingSurfaceSolid(fire.down()) || fire.canNeighborBurn()) {
 
-                    BlockIgniteEvent e =
+                    BlockIgniteEvent event =
                             new BlockIgniteEvent(block, null, this, BlockIgniteEvent.BlockIgniteCause.LIGHTNING);
-                    getServer().getPluginManager().callEvent(e);
+                    event.call();
 
-                    if (!e.isCancelled()) {
+                    if (!event.isCancelled()) {
                         level.setBlock(fire, fire, true);
                         level.scheduleUpdate(
                                 fire,
@@ -180,7 +180,7 @@ public class EntityLightning extends Entity implements EntityLightningStrike {
                             .getStateWithOxidizationLevel(entry.getValue())
                             .getBlock(current);
                     BlockFadeEvent event = new BlockFadeEvent(current, next);
-                    getServer().getPluginManager().callEvent(event);
+                    event.call();
                     if (event.isCancelled()) {
                         break;
                     }
@@ -204,11 +204,11 @@ public class EntityLightning extends Entity implements EntityLightningStrike {
                     Block block = this.getLevelBlock();
 
                     if (block.getId() == Block.AIR || block.getId() == Block.TALL_GRASS) {
-                        BlockIgniteEvent e =
+                        BlockIgniteEvent event =
                                 new BlockIgniteEvent(block, null, this, BlockIgniteEvent.BlockIgniteCause.LIGHTNING);
-                        getServer().getPluginManager().callEvent(e);
+                        event.call();
 
-                        if (!e.isCancelled()) {
+                        if (!event.isCancelled()) {
                             Block fire = Block.get(BlockID.FIRE);
                             this.level.setBlock(block, fire);
                             this.getLevel().scheduleUpdate(fire, fire.tickRate());

--- a/src/main/java/cn/nukkit/event/Cancellable.java
+++ b/src/main/java/cn/nukkit/event/Cancellable.java
@@ -7,7 +7,7 @@ public interface Cancellable {
 
     boolean isCancelled();
 
-    void setCancelled();
+    void cancel();
 
-    void setCancelled(boolean forceCancel);
+    void uncancel();
 }

--- a/src/main/java/cn/nukkit/event/CompiledExecutor.java
+++ b/src/main/java/cn/nukkit/event/CompiledExecutor.java
@@ -1,4 +1,4 @@
-package cn.nukkit.plugin;
+package cn.nukkit.event;
 
 import java.lang.reflect.Method;
 

--- a/src/main/java/cn/nukkit/event/Event.java
+++ b/src/main/java/cn/nukkit/event/Event.java
@@ -1,19 +1,16 @@
 package cn.nukkit.event;
 
-import cn.nukkit.utils.EventException;
+import cn.nukkit.Server;
+import lombok.extern.log4j.Log4j2;
 
 /**
- * 描述服务器中可能发生的事情的类。<br>
- * Describes things that happens in the server.
+ * Describes things that happens in the server.<p>
  *
- * <p>服务器中可能发生的事情称作<b>事件</b>。定义一个需要它在一个事件发生时被运行的过程，这个过程称作<b>监听器</b>。<br>
  * Things that happens in the server is called a <b>event</b>. Define a procedure that should be executed
  * when a event happens, this procedure is called a <b>listener</b>.</p>
  *
- * <p>Nukkit调用事件的处理器时，会通过参数的类型判断需要被监听的事件。<br>
  * When Nukkit is calling a handler, the event needed to listen is judged by the type of the parameter. </p>
  *
- * <p>关于监听器的实现，参阅：{@link Listener} <br>
  * For the way to implement a listener, see: {@link cn.nukkit.event.Listener}</p>
  *
  * @author Unknown(code) @ Nukkit Project
@@ -21,30 +18,70 @@ import cn.nukkit.utils.EventException;
  * @see cn.nukkit.event.EventHandler
  * @since Nukkit 1.0 | Nukkit API 1.0.0
  */
+@Log4j2
 public abstract class Event {
 
+    private static final int MAX_EVENT_CALL_DEPTH = 50;
+
+    private static int eventCallDepth = 1;
+
     protected String eventName = null;
+
     private boolean isCancelled = false;
 
     public final String getEventName() {
         return eventName == null ? getClass().getName() : eventName;
     }
 
+    public void call() {
+        if (eventCallDepth >= MAX_EVENT_CALL_DEPTH) {
+            throw new RuntimeException(
+                    "Recursive event call detected (reached max depth of " + MAX_EVENT_CALL_DEPTH + " calls)");
+        }
+
+        HandlerList handlerList = HandlerListManager.global().getListFor(getEventName());
+
+        ++eventCallDepth;
+        try {
+            for (RegisteredListener registration : handlerList.getListenerList()) {
+                if (!registration.getPlugin().isEnabled()) {
+                    continue;
+                }
+                try {
+                    registration.callEvent(this);
+                } catch (Exception e) {
+                    log.error(
+                            Server.getInstance()
+                                    .getLanguage()
+                                    .tr(
+                                            "nukkit.plugin.eventError",
+                                            getEventName(),
+                                            registration
+                                                    .getPlugin()
+                                                    .getDescription()
+                                                    .getFullName(),
+                                            e.getMessage(),
+                                            registration
+                                                    .getListener()
+                                                    .getClass()
+                                                    .getName()),
+                            e);
+                }
+            }
+        } finally {
+            --eventCallDepth;
+        }
+    }
+
     public boolean isCancelled() {
-        if (!(this instanceof Cancellable)) {
-            throw new EventException("Event is not Cancellable");
-        }
-        return isCancelled;
+        return this instanceof Cancellable && isCancelled;
     }
 
-    public void setCancelled() {
-        setCancelled(true);
+    public void cancel() {
+        isCancelled = true;
     }
 
-    public void setCancelled(boolean value) {
-        if (!(this instanceof Cancellable)) {
-            throw new EventException("Event is not Cancellable");
-        }
-        isCancelled = value;
+    public void uncancel() {
+        isCancelled = false;
     }
 }

--- a/src/main/java/cn/nukkit/event/EventExecutor.java
+++ b/src/main/java/cn/nukkit/event/EventExecutor.java
@@ -1,7 +1,5 @@
-package cn.nukkit.plugin;
+package cn.nukkit.event;
 
-import cn.nukkit.event.Event;
-import cn.nukkit.event.Listener;
 import cn.nukkit.utils.EventException;
 
 /**

--- a/src/main/java/cn/nukkit/event/HandlerList.java
+++ b/src/main/java/cn/nukkit/event/HandlerList.java
@@ -1,10 +1,8 @@
 package cn.nukkit.event;
 
-import cn.nukkit.api.PowerNukkitOnly;
-import cn.nukkit.api.Since;
 import cn.nukkit.plugin.Plugin;
-import cn.nukkit.plugin.RegisteredListener;
 import java.util.*;
+import lombok.Getter;
 
 /**
  * @author Nukkit Team.
@@ -13,63 +11,25 @@ public class HandlerList {
 
     private volatile RegisteredListener[] handlers = null;
 
-    private final EnumMap<EventPriority, ArrayList<RegisteredListener>> handlerslots;
+    @Getter
+    private final EnumMap<EventPriority, ArrayList<RegisteredListener>> handlerSlots;
 
-    private static final ArrayList<HandlerList> allLists = new ArrayList<>();
+    private final String eventName;
 
-    public static void bakeAll() {
-        synchronized (allLists) {
-            for (HandlerList h : allLists) {
-                h.bake();
-            }
-        }
-    }
-
-    public static void unregisterAll() {
-        synchronized (allLists) {
-            for (HandlerList h : allLists) {
-                synchronized (h) {
-                    for (List<RegisteredListener> list : h.handlerslots.values()) {
-                        list.clear();
-                    }
-                    h.handlers = null;
-                }
-            }
-        }
-    }
-
-    public static void unregisterAll(Plugin plugin) {
-        synchronized (allLists) {
-            for (HandlerList h : allLists) {
-                h.unregister(plugin);
-            }
-        }
-    }
-
-    public static void unregisterAll(Listener listener) {
-        synchronized (allLists) {
-            for (HandlerList h : allLists) {
-                h.unregister(listener);
-            }
-        }
-    }
-
-    public HandlerList() {
-        handlerslots = new EnumMap<>(EventPriority.class);
-        for (EventPriority o : EventPriority.values()) {
-            handlerslots.put(o, new ArrayList<>());
-        }
-        synchronized (allLists) {
-            allLists.add(this);
+    public HandlerList(String eventName) {
+        this.eventName = eventName;
+        this.handlerSlots = new EnumMap<>(EventPriority.class);
+        for (EventPriority priority : EventPriority.values()) {
+            handlerSlots.put(priority, new ArrayList<>());
         }
     }
 
     public synchronized void register(RegisteredListener listener) {
-        if (handlerslots.get(listener.getPriority()).contains(listener))
+        if (handlerSlots.get(listener.getPriority()).contains(listener))
             throw new IllegalStateException("This listener is already registered to priority "
-                    + listener.getPriority().toString());
+                    + listener.getPriority().toString() + " of event " + eventName);
         handlers = null;
-        handlerslots.get(listener.getPriority()).add(listener);
+        handlerSlots.get(listener.getPriority()).add(listener);
     }
 
     public void registerAll(Collection<RegisteredListener> listeners) {
@@ -79,27 +39,14 @@ public class HandlerList {
     }
 
     public synchronized void unregister(RegisteredListener listener) {
-        if (handlerslots.get(listener.getPriority()).remove(listener)) {
+        if (handlerSlots.get(listener.getPriority()).remove(listener)) {
             handlers = null;
         }
     }
 
-    public synchronized void unregister(Plugin plugin) {
-        boolean changed = false;
-        for (List<RegisteredListener> list : handlerslots.values()) {
-            for (ListIterator<RegisteredListener> i = list.listIterator(); i.hasNext(); ) {
-                if (i.next().getPlugin().equals(plugin)) {
-                    i.remove();
-                    changed = true;
-                }
-            }
-        }
-        if (changed) handlers = null;
-    }
-
     public synchronized void unregister(Listener listener) {
         boolean changed = false;
-        for (List<RegisteredListener> list : handlerslots.values()) {
+        for (List<RegisteredListener> list : handlerSlots.values()) {
             for (ListIterator<RegisteredListener> i = list.listIterator(); i.hasNext(); ) {
                 if (i.next().getListener().equals(listener)) {
                     i.remove();
@@ -110,16 +57,36 @@ public class HandlerList {
         if (changed) handlers = null;
     }
 
+    public synchronized void unregister(Plugin plugin) {
+        boolean changed = false;
+        for (List<RegisteredListener> list : handlerSlots.values()) {
+            for (ListIterator<RegisteredListener> iterator = list.listIterator(); iterator.hasNext(); ) {
+                if (iterator.next().getPlugin().equals(plugin)) {
+                    iterator.remove();
+                    changed = true;
+                }
+            }
+        }
+        if (changed) handlers = null;
+    }
+
+    public void clear() {
+        for (EventPriority priority : EventPriority.values()) {
+            handlerSlots.put(priority, new ArrayList<>());
+        }
+        handlers = RegisteredListener.EMPTY_ARRAY;
+    }
+
     public synchronized void bake() {
-        if (handlers != null) return; // don't re-bake when still valid
+        if (handlers != null) return; // Don't re-bake when still valid
         List<RegisteredListener> entries = new ArrayList<>();
-        for (Map.Entry<EventPriority, ArrayList<RegisteredListener>> entry : handlerslots.entrySet()) {
+        for (Map.Entry<EventPriority, ArrayList<RegisteredListener>> entry : handlerSlots.entrySet()) {
             entries.addAll(entry.getValue());
         }
         handlers = entries.toArray(RegisteredListener.EMPTY_ARRAY);
     }
 
-    public RegisteredListener[] getRegisteredListeners() {
+    public RegisteredListener[] getListenerList() {
         RegisteredListener[] handlers;
         while ((handlers = this.handlers) == null) {
             bake();
@@ -127,37 +94,15 @@ public class HandlerList {
         return handlers;
     }
 
-    public static ArrayList<RegisteredListener> getRegisteredListeners(Plugin plugin) {
-        ArrayList<RegisteredListener> listeners = new ArrayList<>();
-        synchronized (allLists) {
-            for (HandlerList h : allLists) {
-                synchronized (h) {
-                    for (List<RegisteredListener> list : h.handlerslots.values()) {
-                        for (RegisteredListener listener : list) {
-                            if (listener.getPlugin().equals(plugin)) {
-                                listeners.add(listener);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return listeners;
+    public List<RegisteredListener> getListenersByPriority(EventPriority priority) {
+        return handlerSlots.get(priority);
     }
 
-    public static ArrayList<HandlerList> getHandlerLists() {
-        synchronized (allLists) {
-            return new ArrayList<>(allLists);
-        }
-    }
-
-    @PowerNukkitOnly
-    @Since("1.4.0.0-PN")
     public boolean isEmpty() {
         RegisteredListener[] handlers = this.handlers;
         if (handlers != null) {
             return handlers.length == 0;
         }
-        return getRegisteredListeners().length == 0;
+        return getListenerList().length == 0;
     }
 }

--- a/src/main/java/cn/nukkit/event/HandlerListManager.java
+++ b/src/main/java/cn/nukkit/event/HandlerListManager.java
@@ -1,0 +1,56 @@
+package cn.nukkit.event;
+
+import cn.nukkit.plugin.Plugin;
+import java.util.HashMap;
+
+public class HandlerListManager {
+
+    private static HandlerListManager instance = null;
+
+    private static final HashMap<String, HandlerList> allLists = new HashMap<>();
+
+    public static HandlerListManager global() {
+        return instance != null ? instance : (instance = new HandlerListManager());
+    }
+
+    public void unregisterAll() {
+        synchronized (allLists) {
+            for (HandlerList handler : allLists.values()) {
+                handler.clear();
+            }
+        }
+    }
+
+    public void unregisterAll(Plugin plugin) {
+        synchronized (allLists) {
+            for (HandlerList handler : allLists.values()) {
+                handler.unregister(plugin);
+            }
+        }
+    }
+
+    public void unregisterAll(Listener listener) {
+        synchronized (allLists) {
+            for (HandlerList handler : allLists.values()) {
+                handler.unregister(listener);
+            }
+        }
+    }
+
+    public HandlerList getListFor(Class<? extends Event> event) {
+        return getListFor(event.getName());
+    }
+
+    public HandlerList getListFor(String event) {
+        if (allLists.containsKey(event)) {
+            return allLists.get(event);
+        }
+        HandlerList handler = new HandlerList(event);
+        allLists.put(event, handler);
+        return handler;
+    }
+
+    public HashMap<String, HandlerList> getAll() {
+        return allLists;
+    }
+}

--- a/src/main/java/cn/nukkit/event/MethodEventExecutor.java
+++ b/src/main/java/cn/nukkit/event/MethodEventExecutor.java
@@ -1,9 +1,7 @@
-package cn.nukkit.plugin;
+package cn.nukkit.event;
 
 import static org.objectweb.asm.Opcodes.*;
 
-import cn.nukkit.event.Event;
-import cn.nukkit.event.Listener;
 import cn.nukkit.utils.EventException;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.InaccessibleObjectException;
@@ -68,13 +66,13 @@ public class MethodEventExecutor implements EventExecutor {
         var eventClass = method.getParameterTypes()[0];
         var eventType = Type.getType(eventClass);
         var listenerType = Type.getType(listenerClass);
-        var internalName = "cn/nukkit/plugin/PNXMethodEventExecutor$" + compileTime.incrementAndGet();
+        var internalName = "cn/nukkit/event/PNXMethodEventExecutor$" + compileTime.incrementAndGet();
 
         ClassWriter classWriter = new ClassWriter(0);
         FieldVisitor fieldVisitor;
         MethodVisitor methodVisitor;
         classWriter.visit(V17, ACC_PUBLIC | ACC_SUPER, internalName, null, "java/lang/Object", new String[] {
-            "cn/nukkit/plugin/EventExecutor", "cn/nukkit/plugin/CompiledExecutor"
+            "cn/nukkit/event/EventExecutor", "cn/nukkit/event/CompiledExecutor"
         });
         classWriter.visitSource("EventHandler@" + method.getDeclaringClass().getName() + "#" + method.getName(), null);
         {
@@ -187,7 +185,7 @@ public class MethodEventExecutor implements EventExecutor {
         }
         Objects.requireNonNull(method).setAccessible(true);
         try {
-            var args = new Object[] {"cn.nukkit.plugin.PNXMethodEventExecutor$" + compileTime.get(), b, 0, b.length};
+            var args = new Object[] {"cn.nukkit.event.PNXMethodEventExecutor$" + compileTime.get(), b, 0, b.length};
             clazz = (Class<?>) method.invoke(loader, args);
         } finally {
             method.setAccessible(false);

--- a/src/main/java/cn/nukkit/event/RegisteredListener.java
+++ b/src/main/java/cn/nukkit/event/RegisteredListener.java
@@ -1,25 +1,23 @@
-package cn.nukkit.plugin;
+package cn.nukkit.event;
 
-import cn.nukkit.api.PowerNukkitOnly;
-import cn.nukkit.api.Since;
-import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.Event;
-import cn.nukkit.event.EventPriority;
-import cn.nukkit.event.Listener;
+import cn.nukkit.plugin.Plugin;
 import cn.nukkit.utils.EventException;
+import lombok.Getter;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class RegisteredListener {
-    @PowerNukkitOnly
-    @Since("1.4.0.0-PN")
+
     public static final RegisteredListener[] EMPTY_ARRAY = new RegisteredListener[0];
 
+    @Getter
     private final Listener listener;
 
+    @Getter
     private final EventPriority priority;
 
+    @Getter
     private final Plugin plugin;
 
     private EventExecutor executor;
@@ -33,18 +31,6 @@ public class RegisteredListener {
         this.plugin = plugin;
         this.executor = executor;
         this.ignoreCancelled = ignoreCancelled;
-    }
-
-    public Listener getListener() {
-        return listener;
-    }
-
-    public Plugin getPlugin() {
-        return plugin;
-    }
-
-    public EventPriority getPriority() {
-        return priority;
     }
 
     public void callEvent(Event event) throws EventException {

--- a/src/main/java/cn/nukkit/event/block/AnvilDamageEvent.java
+++ b/src/main/java/cn/nukkit/event/block/AnvilDamageEvent.java
@@ -8,7 +8,6 @@ import cn.nukkit.block.BlockAnvil;
 import cn.nukkit.blockproperty.value.AnvilDamage;
 import cn.nukkit.blockstate.BlockState;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.inventory.transaction.CraftingTransaction;
 import cn.nukkit.player.Player;
 import com.google.common.base.Preconditions;
@@ -17,13 +16,6 @@ import org.jetbrains.annotations.NotNull;
 
 @Since("1.1.1.0-PN")
 public class AnvilDamageEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    @Since("1.1.1.0-PN")
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     @Nullable private final Player player;
 

--- a/src/main/java/cn/nukkit/event/block/BellRingEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BellRingEvent.java
@@ -4,17 +4,9 @@ import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.block.BlockBell;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 @PowerNukkitOnly
 public class BellRingEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    @PowerNukkitOnly
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final RingCause cause;
     private final Entity entity;

--- a/src/main/java/cn/nukkit/event/block/BigDripleafTiltChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BigDripleafTiltChangeEvent.java
@@ -5,17 +5,10 @@ import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockBigDripleaf;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 @PowerNukkitXOnly
 @Since("1.6.0.0-PNX")
 public class BigDripleafTiltChangeEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private BlockBigDripleaf.Tilt oldTilt;
     private BlockBigDripleaf.Tilt newTilt;

--- a/src/main/java/cn/nukkit/event/block/BlockBreakEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockBreakEvent.java
@@ -2,7 +2,6 @@ package cn.nukkit.event.block;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.player.Player;
@@ -11,12 +10,6 @@ import cn.nukkit.player.Player;
  * @author MagicDroidX (Nukkit Project)
  */
 public class BlockBreakEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected final Player player;
 

--- a/src/main/java/cn/nukkit/event/block/BlockBurnEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockBurnEvent.java
@@ -2,20 +2,13 @@ package cn.nukkit.event.block;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class BlockBurnEvent extends BlockEvent implements Cancellable {
 
-    private static final HandlerList handlers = new HandlerList();
-
     public BlockBurnEvent(Block block) {
         super(block);
-    }
-
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/event/block/BlockExplodeEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockExplodeEvent.java
@@ -22,7 +22,6 @@ import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.Position;
 import java.util.Set;
 
@@ -33,14 +32,6 @@ import java.util.Set;
 @PowerNukkitOnly
 @Since("1.4.0.0-PN")
 public class BlockExplodeEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    @PowerNukkitOnly
-    @Since("1.4.0.0-PN")
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     @PowerNukkitOnly
     @Since("1.4.0.0-PN")

--- a/src/main/java/cn/nukkit/event/block/BlockExplosionPrimeEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockExplosionPrimeEvent.java
@@ -23,7 +23,6 @@ import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 import javax.annotation.Nullable;
 
@@ -34,14 +33,6 @@ import javax.annotation.Nullable;
 @PowerNukkitOnly
 @Since("1.4.0.0-PN")
 public class BlockExplosionPrimeEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    @PowerNukkitOnly
-    @Since("1.4.0.0-PN")
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private double force;
     private boolean blockBreaking;

--- a/src/main/java/cn/nukkit/event/block/BlockFadeEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockFadeEvent.java
@@ -2,15 +2,8 @@ package cn.nukkit.event.block;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 public class BlockFadeEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Block newState;
 

--- a/src/main/java/cn/nukkit/event/block/BlockFallEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockFallEvent.java
@@ -4,17 +4,10 @@ import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 @PowerNukkitXOnly
 @Since("1.6.0.0-PNX")
 public class BlockFallEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public BlockFallEvent(Block block) {
         super(block);

--- a/src/main/java/cn/nukkit/event/block/BlockFormEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockFormEvent.java
@@ -2,18 +2,11 @@ package cn.nukkit.event.block;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class BlockFormEvent extends BlockGrowEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public BlockFormEvent(Block block, Block newState) {
         super(block, newState);

--- a/src/main/java/cn/nukkit/event/block/BlockFromToEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockFromToEvent.java
@@ -2,15 +2,8 @@ package cn.nukkit.event.block;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 public class BlockFromToEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private Block to;
 

--- a/src/main/java/cn/nukkit/event/block/BlockGrowEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockGrowEvent.java
@@ -2,18 +2,11 @@ package cn.nukkit.event.block;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class BlockGrowEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Block newState;
 

--- a/src/main/java/cn/nukkit/event/block/BlockHarvestEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockHarvestEvent.java
@@ -3,13 +3,10 @@ package cn.nukkit.event.block;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 
 @PowerNukkitOnly
 public class BlockHarvestEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
 
     private Block newState;
     private Item[] drops;
@@ -39,10 +36,5 @@ public class BlockHarvestEvent extends BlockEvent implements Cancellable {
     @PowerNukkitOnly
     public void setDrops(Item[] drops) {
         this.drops = drops;
-    }
-
-    @PowerNukkitOnly
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/event/block/BlockIgniteEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockIgniteEvent.java
@@ -3,15 +3,8 @@ package cn.nukkit.event.block;
 import cn.nukkit.block.Block;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 public class BlockIgniteEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Block source;
     private final Entity entity;

--- a/src/main/java/cn/nukkit/event/block/BlockPistonChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockPistonChangeEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.block;
 
 import cn.nukkit.block.Block;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @author CreeperFace
@@ -11,12 +10,6 @@ import cn.nukkit.event.HandlerList;
  */
 @Deprecated
 public class BlockPistonChangeEvent extends BlockEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private int oldPower;
     private int newPower;

--- a/src/main/java/cn/nukkit/event/block/BlockPistonEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockPistonEvent.java
@@ -4,20 +4,12 @@ import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockPistonBase;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.math.BlockFace;
 import java.util.ArrayList;
 import java.util.List;
 
 @PowerNukkitOnly
 public class BlockPistonEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    @PowerNukkitOnly
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final BlockFace direction;
     private final List<Block> blocks;

--- a/src/main/java/cn/nukkit/event/block/BlockPlaceEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockPlaceEvent.java
@@ -2,7 +2,6 @@ package cn.nukkit.event.block;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.player.Player;
 
@@ -10,12 +9,6 @@ import cn.nukkit.player.Player;
  * @author MagicDroidX (Nukkit Project)
  */
 public class BlockPlaceEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected final Player player;
 

--- a/src/main/java/cn/nukkit/event/block/BlockRedstoneEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockRedstoneEvent.java
@@ -1,19 +1,12 @@
 package cn.nukkit.event.block;
 
 import cn.nukkit.block.Block;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @author CreeperFace
  * @since 12.5.2017
  */
 public class BlockRedstoneEvent extends BlockEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private int oldPower;
     private int newPower;

--- a/src/main/java/cn/nukkit/event/block/BlockSpreadEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockSpreadEvent.java
@@ -2,18 +2,11 @@ package cn.nukkit.event.block;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class BlockSpreadEvent extends BlockFormEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Block source;
 

--- a/src/main/java/cn/nukkit/event/block/BlockUpdateEvent.java
+++ b/src/main/java/cn/nukkit/event/block/BlockUpdateEvent.java
@@ -2,18 +2,11 @@ package cn.nukkit.event.block;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class BlockUpdateEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public BlockUpdateEvent(Block block) {
         super(block);

--- a/src/main/java/cn/nukkit/event/block/CauldronFilledByDrippingLiquidEvent.java
+++ b/src/main/java/cn/nukkit/event/block/CauldronFilledByDrippingLiquidEvent.java
@@ -1,18 +1,14 @@
 package cn.nukkit.event.block;
 
-import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.blockproperty.value.CauldronLiquid;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 @PowerNukkitXOnly
 @Since("1.6.0.0-PNX")
 public class CauldronFilledByDrippingLiquidEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
 
     private CauldronLiquid liquid;
 
@@ -38,10 +34,5 @@ public class CauldronFilledByDrippingLiquidEvent extends BlockEvent implements C
 
     public void setLiquidLevelIncrement(int liquidLevelIncrement) {
         this.liquidLevelIncrement = liquidLevelIncrement;
-    }
-
-    @PowerNukkitOnly
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/event/block/ComposterEmptyEvent.java
+++ b/src/main/java/cn/nukkit/event/block/ComposterEmptyEvent.java
@@ -3,15 +3,12 @@ package cn.nukkit.event.block;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.player.Player;
 
 @PowerNukkitOnly
 public class ComposterEmptyEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
 
     private final Player player;
     private Item drop;
@@ -76,10 +73,5 @@ public class ComposterEmptyEvent extends BlockEvent implements Cancellable {
     @PowerNukkitOnly
     public void setMotion(Vector3 motion) {
         this.motion = motion;
-    }
-
-    @PowerNukkitOnly
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/event/block/ComposterFillEvent.java
+++ b/src/main/java/cn/nukkit/event/block/ComposterFillEvent.java
@@ -3,14 +3,11 @@ package cn.nukkit.event.block;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.player.Player;
 
 @PowerNukkitOnly
 public class ComposterFillEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
 
     private final Player player;
     private final Item item;
@@ -49,10 +46,5 @@ public class ComposterFillEvent extends BlockEvent implements Cancellable {
     @PowerNukkitOnly
     public void setSuccess(boolean success) {
         this.success = success;
-    }
-
-    @PowerNukkitOnly
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/event/block/ConduitActivateEvent.java
+++ b/src/main/java/cn/nukkit/event/block/ConduitActivateEvent.java
@@ -2,20 +2,12 @@ package cn.nukkit.event.block;
 
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.block.Block;
-import cn.nukkit.event.HandlerList;
 
 @PowerNukkitOnly
 public class ConduitActivateEvent extends BlockEvent {
 
-    private static final HandlerList handlers = new HandlerList();
-
     @PowerNukkitOnly
     public ConduitActivateEvent(Block block) {
         super(block);
-    }
-
-    @PowerNukkitOnly
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/event/block/ConduitDeactivateEvent.java
+++ b/src/main/java/cn/nukkit/event/block/ConduitDeactivateEvent.java
@@ -2,20 +2,12 @@ package cn.nukkit.event.block;
 
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.block.Block;
-import cn.nukkit.event.HandlerList;
 
 @PowerNukkitOnly
 public class ConduitDeactivateEvent extends BlockEvent {
 
-    private static final HandlerList handlers = new HandlerList();
-
     @PowerNukkitOnly
     public ConduitDeactivateEvent(Block block) {
         super(block);
-    }
-
-    @PowerNukkitOnly
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/event/block/DoorToggleEvent.java
+++ b/src/main/java/cn/nukkit/event/block/DoorToggleEvent.java
@@ -2,7 +2,6 @@ package cn.nukkit.event.block;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 /**
@@ -10,12 +9,6 @@ import cn.nukkit.player.Player;
  * @since 2016/1/22
  */
 public class DoorToggleEvent extends BlockUpdateEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private Player player;
 

--- a/src/main/java/cn/nukkit/event/block/FarmLandDecayEvent.java
+++ b/src/main/java/cn/nukkit/event/block/FarmLandDecayEvent.java
@@ -5,17 +5,11 @@ import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import javax.annotation.Nullable;
 
 @PowerNukkitXOnly
 @Since("1.19.60-r1")
 public class FarmLandDecayEvent extends BlockEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Entity entity;
 

--- a/src/main/java/cn/nukkit/event/block/HopperSearchItemEvent.java
+++ b/src/main/java/cn/nukkit/event/block/HopperSearchItemEvent.java
@@ -5,16 +5,10 @@ import cn.nukkit.api.Since;
 import cn.nukkit.block.BlockHopper;
 import cn.nukkit.event.Cancellable;
 import cn.nukkit.event.Event;
-import cn.nukkit.event.HandlerList;
 
 @PowerNukkitXOnly
 @Since("1.19.60-r1")
 public class HopperSearchItemEvent extends Event implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final BlockHopper.IHopper hopper;
 

--- a/src/main/java/cn/nukkit/event/block/ItemFrameUseEvent.java
+++ b/src/main/java/cn/nukkit/event/block/ItemFrameUseEvent.java
@@ -5,7 +5,6 @@ import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.blockentity.BlockEntityItemFrame;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.player.Player;
 import javax.annotation.Nullable;
@@ -19,15 +18,11 @@ import org.jetbrains.annotations.NotNull;
 @PowerNukkitXOnly
 @Since("1.19.62-r1")
 public class ItemFrameUseEvent extends BlockEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
+
     protected final Player player;
     protected final Item item;
     protected final BlockEntityItemFrame itemFrame;
     protected final Action action;
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public ItemFrameUseEvent(
             @Nullable Player player,

--- a/src/main/java/cn/nukkit/event/block/LeavesDecayEvent.java
+++ b/src/main/java/cn/nukkit/event/block/LeavesDecayEvent.java
@@ -2,18 +2,11 @@ package cn.nukkit.event.block;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class LeavesDecayEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public LeavesDecayEvent(Block block) {
         super(block);

--- a/src/main/java/cn/nukkit/event/block/LecternDropBookEvent.java
+++ b/src/main/java/cn/nukkit/event/block/LecternDropBookEvent.java
@@ -3,14 +3,12 @@ package cn.nukkit.event.block;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.blockentity.BlockEntityLectern;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.player.Player;
 
 @PowerNukkitOnly
 public class LecternDropBookEvent extends BlockEvent implements Cancellable {
 
-    private static final HandlerList handlers = new HandlerList();
     private final Player player;
     private final BlockEntityLectern lectern;
     private Item book;
@@ -21,11 +19,6 @@ public class LecternDropBookEvent extends BlockEvent implements Cancellable {
         this.player = player;
         this.lectern = lectern;
         this.book = book;
-    }
-
-    @PowerNukkitOnly
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 
     @PowerNukkitOnly

--- a/src/main/java/cn/nukkit/event/block/LecternPageChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/block/LecternPageChangeEvent.java
@@ -3,13 +3,11 @@ package cn.nukkit.event.block;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.blockentity.BlockEntityLectern;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 @PowerNukkitOnly
 public class LecternPageChangeEvent extends BlockEvent implements Cancellable {
 
-    private static final HandlerList handlers = new HandlerList();
     private final Player player;
     private final BlockEntityLectern lectern;
     private int newRawPage;
@@ -20,11 +18,6 @@ public class LecternPageChangeEvent extends BlockEvent implements Cancellable {
         this.player = player;
         this.lectern = lectern;
         this.newRawPage = newPage;
-    }
-
-    @PowerNukkitOnly
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 
     @PowerNukkitOnly

--- a/src/main/java/cn/nukkit/event/block/LecternPlaceBookEvent.java
+++ b/src/main/java/cn/nukkit/event/block/LecternPlaceBookEvent.java
@@ -3,14 +3,12 @@ package cn.nukkit.event.block;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.blockentity.BlockEntityLectern;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.player.Player;
 
 @PowerNukkitOnly
 public class LecternPlaceBookEvent extends BlockEvent implements Cancellable {
 
-    private static final HandlerList handlers = new HandlerList();
     private final Player player;
     private final BlockEntityLectern lectern;
     private Item book;
@@ -21,11 +19,6 @@ public class LecternPlaceBookEvent extends BlockEvent implements Cancellable {
         this.player = player;
         this.lectern = lectern;
         this.book = book;
-    }
-
-    @PowerNukkitOnly
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 
     @PowerNukkitOnly

--- a/src/main/java/cn/nukkit/event/block/LiquidFlowEvent.java
+++ b/src/main/java/cn/nukkit/event/block/LiquidFlowEvent.java
@@ -3,15 +3,8 @@ package cn.nukkit.event.block;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockLiquid;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 public class LiquidFlowEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Block to;
     private final BlockLiquid source;

--- a/src/main/java/cn/nukkit/event/block/SignChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/block/SignChangeEvent.java
@@ -2,18 +2,12 @@ package cn.nukkit.event.block;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class SignChangeEvent extends BlockEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Player player;
 

--- a/src/main/java/cn/nukkit/event/block/SignColorChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/block/SignColorChangeEvent.java
@@ -2,17 +2,10 @@ package cn.nukkit.event.block;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 import cn.nukkit.utils.BlockColor;
 
 public class SignColorChangeEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Player player;
     private final BlockColor color;

--- a/src/main/java/cn/nukkit/event/block/SignGlowEvent.java
+++ b/src/main/java/cn/nukkit/event/block/SignGlowEvent.java
@@ -2,16 +2,9 @@ package cn.nukkit.event.block;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 public class SignGlowEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Player player;
     private final boolean glowing;

--- a/src/main/java/cn/nukkit/event/block/SignWaxedEvent.java
+++ b/src/main/java/cn/nukkit/event/block/SignWaxedEvent.java
@@ -4,18 +4,11 @@ import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 @Since("1.20.0-r2")
 @PowerNukkitXOnly
 public class SignWaxedEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Player player;
     private final boolean waxed;

--- a/src/main/java/cn/nukkit/event/block/TurtleEggHatchEvent.java
+++ b/src/main/java/cn/nukkit/event/block/TurtleEggHatchEvent.java
@@ -5,12 +5,9 @@ import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockAir;
 import cn.nukkit.block.BlockTurtleEgg;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 @PowerNukkitOnly
 public class TurtleEggHatchEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
 
     private int eggsHatching;
     private Block newState;
@@ -70,10 +67,5 @@ public class TurtleEggHatchEvent extends BlockEvent implements Cancellable {
     @PowerNukkitOnly
     public void setRecalculateOnFailure(boolean recalculateOnFailure) {
         this.recalculateOnFailure = recalculateOnFailure;
-    }
-
-    @PowerNukkitOnly
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/event/block/WaterFrostEvent.java
+++ b/src/main/java/cn/nukkit/event/block/WaterFrostEvent.java
@@ -4,17 +4,9 @@ import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.block.Block;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 @PowerNukkitOnly
 public class WaterFrostEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    @PowerNukkitOnly
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     @PowerNukkitOnly
     protected final Entity entity;

--- a/src/main/java/cn/nukkit/event/blockstate/BlockStateRepairEvent.java
+++ b/src/main/java/cn/nukkit/event/blockstate/BlockStateRepairEvent.java
@@ -4,7 +4,6 @@ import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockstate.BlockStateRepair;
 import cn.nukkit.event.Event;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @author joserobjr
@@ -12,13 +11,6 @@ import cn.nukkit.event.HandlerList;
 @PowerNukkitOnly
 @Since("1.4.0.0-PN")
 public class BlockStateRepairEvent extends Event {
-    private static final HandlerList handlers = new HandlerList();
-
-    @PowerNukkitOnly
-    @Since("1.4.0.0-PN")
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final BlockStateRepair repair;
 

--- a/src/main/java/cn/nukkit/event/blockstate/BlockStateRepairFinishEvent.java
+++ b/src/main/java/cn/nukkit/event/blockstate/BlockStateRepairFinishEvent.java
@@ -4,7 +4,6 @@ import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.blockstate.BlockStateRepair;
-import cn.nukkit.event.HandlerList;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,13 +43,5 @@ public class BlockStateRepairFinishEvent extends BlockStateRepairEvent {
     @Since("1.4.0.0-PN")
     public void setResult(@NotNull Block result) {
         this.result = Preconditions.checkNotNull(result);
-    }
-
-    @NotNull private static final HandlerList handlers = new HandlerList();
-
-    @PowerNukkitOnly
-    @Since("1.4.0.0-PN")
-    @NotNull public static HandlerList getHandlers() {
-        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/event/command/CommandBlockExecuteEvent.java
+++ b/src/main/java/cn/nukkit/event/command/CommandBlockExecuteEvent.java
@@ -1,18 +1,15 @@
 package cn.nukkit.event.command;
 
-import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.event.block.BlockEvent;
 
 @PowerNukkitXOnly
 @Since("1.6.0.0-PNX")
 public class CommandBlockExecuteEvent extends BlockEvent implements Cancellable {
 
-    private static final HandlerList handlers = new HandlerList();
     private String command;
 
     public CommandBlockExecuteEvent(Block block, String command) {
@@ -26,10 +23,5 @@ public class CommandBlockExecuteEvent extends BlockEvent implements Cancellable 
 
     public void setCommand(String command) {
         this.command = command;
-    }
-
-    @PowerNukkitOnly
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/event/entity/CreatureSpawnEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/CreatureSpawnEvent.java
@@ -4,17 +4,10 @@ import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
 import cn.nukkit.event.Event;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.Position;
 import cn.nukkit.nbt.tag.CompoundTag;
 
 public class CreatureSpawnEvent extends Event implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final SpawnReason reason;
     private final int entityNetworkId;

--- a/src/main/java/cn/nukkit/event/entity/CreeperPowerEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/CreeperPowerEvent.java
@@ -3,17 +3,11 @@ package cn.nukkit.event.entity;
 import cn.nukkit.entity.mob.EntityCreeper;
 import cn.nukkit.entity.weather.EntityLightningStrike;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class CreeperPowerEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final PowerCause cause;
     private EntityLightningStrike bolt;

--- a/src/main/java/cn/nukkit/event/entity/EntityArmorChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityArmorChangeEvent.java
@@ -2,18 +2,12 @@ package cn.nukkit.event.entity;
 
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class EntityArmorChangeEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Item oldItem;
     private Item newItem;

--- a/src/main/java/cn/nukkit/event/entity/EntityBlockChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityBlockChangeEvent.java
@@ -3,17 +3,11 @@ package cn.nukkit.event.entity;
 import cn.nukkit.block.Block;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @since 15-10-26
  */
 public class EntityBlockChangeEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Block from;
     private final Block to;

--- a/src/main/java/cn/nukkit/event/entity/EntityCombustEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityCombustEvent.java
@@ -2,17 +2,11 @@ package cn.nukkit.event.entity;
 
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class EntityCombustEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected int duration;
 

--- a/src/main/java/cn/nukkit/event/entity/EntityDamageBlockedEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityDamageBlockedEvent.java
@@ -4,19 +4,10 @@ import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 @PowerNukkitOnly
 @Since("1.4.0.0-PN")
 public class EntityDamageBlockedEvent extends EntityEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    @PowerNukkitOnly
-    @Since("1.4.0.0-PN")
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final EntityDamageEvent damage;
     private boolean knockBackAttacker;

--- a/src/main/java/cn/nukkit/event/entity/EntityDamageEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityDamageEvent.java
@@ -5,7 +5,6 @@ import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.potion.Effect;
 import cn.nukkit.utils.EventException;
 import com.google.common.collect.ImmutableMap;
@@ -16,11 +15,6 @@ import java.util.Map;
  * @author MagicDroidX (Nukkit Project)
  */
 public class EntityDamageEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private int attackCooldown = 10;
     private final DamageCause cause;

--- a/src/main/java/cn/nukkit/event/entity/EntityDeathEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityDeathEvent.java
@@ -1,18 +1,12 @@
 package cn.nukkit.event.entity;
 
 import cn.nukkit.entity.EntityLiving;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class EntityDeathEvent extends EntityEvent {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private Item[] drops;
 

--- a/src/main/java/cn/nukkit/event/entity/EntityDespawnEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityDespawnEvent.java
@@ -7,7 +7,6 @@ import cn.nukkit.entity.EntityHuman;
 import cn.nukkit.entity.item.EntityItem;
 import cn.nukkit.entity.projectile.EntityProjectile;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.Position;
 
 /**
@@ -15,11 +14,6 @@ import cn.nukkit.level.Position;
  */
 @PowerNukkitDifference(since = "1.4.0.0-PN", info = "Is cancellable only in PowerNukkit")
 public class EntityDespawnEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final int entityType;
 

--- a/src/main/java/cn/nukkit/event/entity/EntityEffectRemoveEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityEffectRemoveEvent.java
@@ -3,22 +3,16 @@ package cn.nukkit.event.entity;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.potion.Effect;
 
 @PowerNukkitXOnly
 public class EntityEffectRemoveEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
 
     private Effect removeEffect;
 
     public EntityEffectRemoveEvent(Entity entity, Effect effect) {
         this.entity = entity;
         this.removeEffect = effect;
-    }
-
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 
     public Effect getRemoveEffect() {

--- a/src/main/java/cn/nukkit/event/entity/EntityEffectUpdateEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityEffectUpdateEvent.java
@@ -3,12 +3,10 @@ package cn.nukkit.event.entity;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.potion.Effect;
 
 @PowerNukkitXOnly
 public class EntityEffectUpdateEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
 
     private Effect oldEffect;
     private Effect newEffect;
@@ -17,10 +15,6 @@ public class EntityEffectUpdateEvent extends EntityEvent implements Cancellable 
         this.entity = entity;
         this.oldEffect = oldEffect;
         this.newEffect = newEffect;
-    }
-
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 
     public Effect getOldEffect() {

--- a/src/main/java/cn/nukkit/event/entity/EntityExplodeEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityExplodeEvent.java
@@ -5,7 +5,6 @@ import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.Position;
 import java.util.HashSet;
 import java.util.List;
@@ -15,12 +14,6 @@ import java.util.Set;
  * @author Angelic47 (Nukkit Project)
  */
 public class EntityExplodeEvent extends EntityEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected final Position position;
     protected List<Block> blocks;

--- a/src/main/java/cn/nukkit/event/entity/EntityExplosionPrimeEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityExplosionPrimeEvent.java
@@ -4,18 +4,11 @@ import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @since 15-10-27
  */
 public class EntityExplosionPrimeEvent extends EntityEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private double force;
     private boolean blockBreaking;

--- a/src/main/java/cn/nukkit/event/entity/EntityFallEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityFallEvent.java
@@ -3,14 +3,8 @@ package cn.nukkit.event.entity;
 import cn.nukkit.block.Block;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 public class EntityFallEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private Block blockFallOn;
     private float fallDistance;

--- a/src/main/java/cn/nukkit/event/entity/EntityInteractEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityInteractEvent.java
@@ -3,18 +3,11 @@ package cn.nukkit.event.entity;
 import cn.nukkit.block.Block;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @author CreeperFace
  */
 public class EntityInteractEvent extends EntityEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private Block block;
 

--- a/src/main/java/cn/nukkit/event/entity/EntityInventoryChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityInventoryChangeEvent.java
@@ -2,18 +2,12 @@ package cn.nukkit.event.entity;
 
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class EntityInventoryChangeEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Item oldItem;
     private Item newItem;

--- a/src/main/java/cn/nukkit/event/entity/EntityLevelChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityLevelChangeEvent.java
@@ -2,18 +2,12 @@ package cn.nukkit.event.entity;
 
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.Level;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class EntityLevelChangeEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Level originLevel;
     private final Level targetLevel;

--- a/src/main/java/cn/nukkit/event/entity/EntityMotionEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityMotionEvent.java
@@ -2,18 +2,12 @@ package cn.nukkit.event.entity;
 
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.math.Vector3;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class EntityMotionEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Vector3 motion;
 

--- a/src/main/java/cn/nukkit/event/entity/EntityPortalEnterEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityPortalEnterEvent.java
@@ -2,16 +2,10 @@ package cn.nukkit.event.entity;
 
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 public class EntityPortalEnterEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
 
     private final PortalType type;
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public EntityPortalEnterEvent(Entity entity, PortalType type) {
         this.entity = entity;

--- a/src/main/java/cn/nukkit/event/entity/EntityRegainHealthEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityRegainHealthEvent.java
@@ -2,17 +2,11 @@ package cn.nukkit.event.entity;
 
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class EntityRegainHealthEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public static final int CAUSE_REGEN = 0;
     public static final int CAUSE_EATING = 1;

--- a/src/main/java/cn/nukkit/event/entity/EntityShootBowEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityShootBowEvent.java
@@ -4,18 +4,12 @@ import cn.nukkit.entity.Entity;
 import cn.nukkit.entity.EntityLiving;
 import cn.nukkit.entity.projectile.EntityProjectile;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 
 /**
  * @author Box (Nukkit Project)
  */
 public class EntityShootBowEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Item bow;
 

--- a/src/main/java/cn/nukkit/event/entity/EntityShootCrossbowEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityShootCrossbowEvent.java
@@ -3,19 +3,12 @@ package cn.nukkit.event.entity;
 import cn.nukkit.entity.EntityLiving;
 import cn.nukkit.entity.projectile.EntityProjectile;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 
 /**
  * @author GoodLucky777, Superice666
  */
 public class EntityShootCrossbowEvent extends EntityEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Item crossbow;
 

--- a/src/main/java/cn/nukkit/event/entity/EntitySpawnEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntitySpawnEvent.java
@@ -7,7 +7,6 @@ import cn.nukkit.entity.EntityHuman;
 import cn.nukkit.entity.item.EntityItem;
 import cn.nukkit.entity.projectile.EntityProjectile;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.Position;
 
 /**
@@ -15,11 +14,6 @@ import cn.nukkit.level.Position;
  */
 @PowerNukkitDifference(since = "1.4.0.0-PN", info = "Is cancellable only in PowerNukkit")
 public class EntitySpawnEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final int entityType;
 

--- a/src/main/java/cn/nukkit/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityTeleportEvent.java
@@ -2,7 +2,6 @@ package cn.nukkit.event.entity;
 
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.event.player.PlayerTeleportEvent;
 import cn.nukkit.level.Location;
 
@@ -10,11 +9,6 @@ import cn.nukkit.level.Location;
  * @author MagicDroidX (Nukkit Project)
  */
 public class EntityTeleportEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private Location from;
     private Location to;

--- a/src/main/java/cn/nukkit/event/entity/EntityVehicleEnterEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityVehicleEnterEvent.java
@@ -2,15 +2,8 @@ package cn.nukkit.event.entity;
 
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 public class EntityVehicleEnterEvent extends EntityEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Entity vehicle;
 

--- a/src/main/java/cn/nukkit/event/entity/EntityVehicleExitEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityVehicleExitEvent.java
@@ -2,15 +2,8 @@ package cn.nukkit.event.entity;
 
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 public class EntityVehicleExitEvent extends EntityEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Entity vehicle;
 

--- a/src/main/java/cn/nukkit/event/entity/ExplosionPrimeEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/ExplosionPrimeEvent.java
@@ -2,7 +2,6 @@ package cn.nukkit.event.entity;
 
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @author Box (Nukkit Project)
@@ -10,11 +9,6 @@ import cn.nukkit.event.HandlerList;
  * Called when a entity decides to explode
  */
 public class ExplosionPrimeEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected double force;
     private boolean blockBreaking;

--- a/src/main/java/cn/nukkit/event/entity/ItemDespawnEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/ItemDespawnEvent.java
@@ -2,17 +2,11 @@ package cn.nukkit.event.entity;
 
 import cn.nukkit.entity.item.EntityItem;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemDespawnEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public ItemDespawnEvent(EntityItem item) {
         this.entity = item;

--- a/src/main/java/cn/nukkit/event/entity/ItemSpawnEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/ItemSpawnEvent.java
@@ -3,18 +3,12 @@ package cn.nukkit.event.entity;
 import cn.nukkit.api.PowerNukkitDifference;
 import cn.nukkit.entity.item.EntityItem;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 @PowerNukkitDifference(since = "1.4.0.0-PN", info = "Is cancellable only in PowerNukkit")
 public class ItemSpawnEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public ItemSpawnEvent(EntityItem item) {
         this.entity = item;

--- a/src/main/java/cn/nukkit/event/entity/ProjectileHitEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/ProjectileHitEvent.java
@@ -2,18 +2,12 @@ package cn.nukkit.event.entity;
 
 import cn.nukkit.entity.projectile.EntityProjectile;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.MovingObjectPosition;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ProjectileHitEvent extends EntityEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private MovingObjectPosition movingObjectPosition;
 

--- a/src/main/java/cn/nukkit/event/entity/ProjectileLaunchEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/ProjectileLaunchEvent.java
@@ -6,15 +6,10 @@ import cn.nukkit.api.Since;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.entity.projectile.EntityProjectile;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 public class ProjectileLaunchEvent extends EntityEvent implements Cancellable {
-    protected Entity shooter;
-    private static final HandlerList handlers = new HandlerList();
 
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
+    protected Entity shooter;
 
     @Deprecated // 保留这个方法，兼容nk插件
     public ProjectileLaunchEvent(EntityProjectile entity) {

--- a/src/main/java/cn/nukkit/event/inventory/BrewEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/BrewEvent.java
@@ -2,19 +2,12 @@ package cn.nukkit.event.inventory;
 
 import cn.nukkit.blockentity.BlockEntityBrewingStand;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 
 /**
  * @author CreeperFace
  */
 public class BrewEvent extends InventoryEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final BlockEntityBrewingStand brewingStand;
     private final Item ingredient;

--- a/src/main/java/cn/nukkit/event/inventory/CampfireSmeltEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/CampfireSmeltEvent.java
@@ -3,7 +3,6 @@ package cn.nukkit.event.inventory;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.blockentity.BlockEntityCampfire;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.event.block.BlockEvent;
 import cn.nukkit.item.Item;
 
@@ -12,13 +11,6 @@ import cn.nukkit.item.Item;
  */
 @PowerNukkitOnly
 public class CampfireSmeltEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    @PowerNukkitOnly
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final BlockEntityCampfire campfire;
     private final Item source;

--- a/src/main/java/cn/nukkit/event/inventory/CraftItemEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/CraftItemEvent.java
@@ -2,7 +2,6 @@ package cn.nukkit.event.inventory;
 
 import cn.nukkit.event.Cancellable;
 import cn.nukkit.event.Event;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.inventory.Recipe;
 import cn.nukkit.inventory.transaction.CraftingTransaction;
 import cn.nukkit.item.Item;
@@ -12,12 +11,6 @@ import cn.nukkit.player.Player;
  * @author MagicDroidX (Nukkit Project)
  */
 public class CraftItemEvent extends Event implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private Item[] input = Item.EMPTY_ARRAY;
 

--- a/src/main/java/cn/nukkit/event/inventory/EnchantItemEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/EnchantItemEvent.java
@@ -2,18 +2,12 @@ package cn.nukkit.event.inventory;
 
 import cn.nukkit.api.Since;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.inventory.EnchantInventory;
 import cn.nukkit.item.Item;
 import cn.nukkit.player.Player;
 
 @Since("1.3.1.0-PN")
 public class EnchantItemEvent extends InventoryEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private Item oldItem;
     private Item newItem;

--- a/src/main/java/cn/nukkit/event/inventory/FurnaceBurnEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/FurnaceBurnEvent.java
@@ -2,7 +2,6 @@ package cn.nukkit.event.inventory;
 
 import cn.nukkit.blockentity.BlockEntityFurnace;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.event.block.BlockEvent;
 import cn.nukkit.item.Item;
 
@@ -10,12 +9,6 @@ import cn.nukkit.item.Item;
  * @author MagicDroidX (Nukkit Project)
  */
 public class FurnaceBurnEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final BlockEntityFurnace furnace;
     private final Item fuel;

--- a/src/main/java/cn/nukkit/event/inventory/FurnaceSmeltEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/FurnaceSmeltEvent.java
@@ -4,7 +4,6 @@ import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockentity.BlockEntityFurnace;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.event.block.BlockEvent;
 import cn.nukkit.item.Item;
 
@@ -12,12 +11,6 @@ import cn.nukkit.item.Item;
  * @author MagicDroidX (Nukkit Project)
  */
 public class FurnaceSmeltEvent extends BlockEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final BlockEntityFurnace furnace;
     private final Item source;

--- a/src/main/java/cn/nukkit/event/inventory/GrindstoneEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/GrindstoneEvent.java
@@ -21,7 +21,6 @@ package cn.nukkit.event.inventory;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.inventory.GrindstoneInventory;
 import cn.nukkit.item.Item;
 import cn.nukkit.player.Player;
@@ -34,13 +33,6 @@ import org.jetbrains.annotations.NotNull;
 @PowerNukkitOnly
 @Since("1.4.0.0-PN")
 public class GrindstoneEvent extends InventoryEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    @PowerNukkitOnly
-    @Since("1.4.0.0-PN")
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final @NotNull Item firstItem;
     private final @NotNull Item resultItem;

--- a/src/main/java/cn/nukkit/event/inventory/InventoryClickEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/InventoryClickEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.inventory;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.inventory.Inventory;
 import cn.nukkit.item.Item;
 import cn.nukkit.player.Player;
@@ -10,12 +9,6 @@ import cn.nukkit.player.Player;
  * @author boybook (Nukkit Project)
  */
 public class InventoryClickEvent extends InventoryEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final int slot;
     private final Item sourceItem;

--- a/src/main/java/cn/nukkit/event/inventory/InventoryCloseEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/InventoryCloseEvent.java
@@ -1,6 +1,5 @@
 package cn.nukkit.event.inventory;
 
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.inventory.Inventory;
 import cn.nukkit.player.Player;
 
@@ -8,12 +7,6 @@ import cn.nukkit.player.Player;
  * @author Box (Nukkit Project)
  */
 public class InventoryCloseEvent extends InventoryEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Player who;
 

--- a/src/main/java/cn/nukkit/event/inventory/InventoryMoveItemEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/InventoryMoveItemEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.inventory;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.inventory.Inventory;
 import cn.nukkit.inventory.InventoryHolder;
 import cn.nukkit.item.Item;
@@ -12,12 +11,6 @@ import cn.nukkit.item.Item;
  * Called when inventory transaction is not caused by a player
  */
 public class InventoryMoveItemEvent extends InventoryEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Inventory targetInventory;
     private final InventoryHolder source;

--- a/src/main/java/cn/nukkit/event/inventory/InventoryOpenEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/InventoryOpenEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.inventory;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.inventory.Inventory;
 import cn.nukkit.player.Player;
 
@@ -9,12 +8,6 @@ import cn.nukkit.player.Player;
  * @author Box (Nukkit Project)
  */
 public class InventoryOpenEvent extends InventoryEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Player who;
 

--- a/src/main/java/cn/nukkit/event/inventory/InventoryPickupArrowEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/InventoryPickupArrowEvent.java
@@ -2,19 +2,12 @@ package cn.nukkit.event.inventory;
 
 import cn.nukkit.entity.projectile.EntityArrow;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.inventory.Inventory;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class InventoryPickupArrowEvent extends InventoryEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final EntityArrow arrow;
 

--- a/src/main/java/cn/nukkit/event/inventory/InventoryPickupItemEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/InventoryPickupItemEvent.java
@@ -2,19 +2,12 @@ package cn.nukkit.event.inventory;
 
 import cn.nukkit.entity.item.EntityItem;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.inventory.Inventory;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class InventoryPickupItemEvent extends InventoryEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final EntityItem item;
 

--- a/src/main/java/cn/nukkit/event/inventory/InventoryPickupTridentEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/InventoryPickupTridentEvent.java
@@ -3,18 +3,10 @@ package cn.nukkit.event.inventory;
 import cn.nukkit.api.Since;
 import cn.nukkit.entity.projectile.EntityThrownTrident;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.inventory.Inventory;
 
 @Since("1.4.0.0-PN")
 public class InventoryPickupTridentEvent extends InventoryEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    @Since("1.4.0.0-PN")
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final EntityThrownTrident trident;
 

--- a/src/main/java/cn/nukkit/event/inventory/InventoryTransactionEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/InventoryTransactionEvent.java
@@ -2,19 +2,12 @@ package cn.nukkit.event.inventory;
 
 import cn.nukkit.event.Cancellable;
 import cn.nukkit.event.Event;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.inventory.transaction.InventoryTransaction;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class InventoryTransactionEvent extends Event implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final InventoryTransaction transaction;
 

--- a/src/main/java/cn/nukkit/event/inventory/PlayerTypingAnvilInventoryEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/PlayerTypingAnvilInventoryEvent.java
@@ -20,7 +20,6 @@ package cn.nukkit.event.inventory;
 
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.inventory.AnvilInventory;
 import cn.nukkit.player.Player;
 import javax.annotation.Nullable;
@@ -37,13 +36,6 @@ import org.jetbrains.annotations.NotNull;
 @Since("1.4.0.0-PN")
 @ToString
 public class PlayerTypingAnvilInventoryEvent extends InventoryEvent {
-    private static final HandlerList handlers = new HandlerList();
-
-    @PowerNukkitOnly
-    @Since("1.4.0.0-PN")
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Player player;
     private final String previousName;

--- a/src/main/java/cn/nukkit/event/inventory/RepairItemEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/RepairItemEvent.java
@@ -2,20 +2,12 @@ package cn.nukkit.event.inventory;
 
 import cn.nukkit.api.Since;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.inventory.AnvilInventory;
 import cn.nukkit.item.Item;
 import cn.nukkit.player.Player;
 
 @Since("1.4.0.0-PN")
 public class RepairItemEvent extends InventoryEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    @Since("1.4.0.0-PN")
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private Item oldItem;
     private Item newItem;

--- a/src/main/java/cn/nukkit/event/inventory/SmithingTableEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/SmithingTableEvent.java
@@ -21,7 +21,6 @@ package cn.nukkit.event.inventory;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.inventory.SmithingInventory;
 import cn.nukkit.item.Item;
 import cn.nukkit.player.Player;
@@ -34,13 +33,6 @@ import org.jetbrains.annotations.NotNull;
 @PowerNukkitOnly
 @Since("1.4.0.0-PN")
 public class SmithingTableEvent extends InventoryEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    @PowerNukkitOnly
-    @Since("1.4.0.0-PN")
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final @NotNull Item equipmentItem;
     private final @NotNull Item resultItem;

--- a/src/main/java/cn/nukkit/event/inventory/StartBrewEvent.java
+++ b/src/main/java/cn/nukkit/event/inventory/StartBrewEvent.java
@@ -2,19 +2,12 @@ package cn.nukkit.event.inventory;
 
 import cn.nukkit.blockentity.BlockEntityBrewingStand;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 
 /**
  * @author CreeperFace
  */
 public class StartBrewEvent extends InventoryEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final BlockEntityBrewingStand brewingStand;
     private final Item ingredient;

--- a/src/main/java/cn/nukkit/event/level/ChunkLoadEvent.java
+++ b/src/main/java/cn/nukkit/event/level/ChunkLoadEvent.java
@@ -1,18 +1,11 @@
 package cn.nukkit.event.level;
 
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.format.FullChunk;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ChunkLoadEvent extends ChunkEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final boolean newChunk;
 

--- a/src/main/java/cn/nukkit/event/level/ChunkPopulateEvent.java
+++ b/src/main/java/cn/nukkit/event/level/ChunkPopulateEvent.java
@@ -1,18 +1,11 @@
 package cn.nukkit.event.level;
 
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.format.FullChunk;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ChunkPopulateEvent extends ChunkEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public ChunkPopulateEvent(FullChunk chunk) {
         super(chunk);

--- a/src/main/java/cn/nukkit/event/level/ChunkPrePopulateEvent.java
+++ b/src/main/java/cn/nukkit/event/level/ChunkPrePopulateEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.level;
 
 import cn.nukkit.api.ImmutableCollection;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.format.FullChunk;
 import cn.nukkit.level.generator.populator.type.Populator;
 import java.util.Collections;
@@ -9,11 +8,6 @@ import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
 public class ChunkPrePopulateEvent extends ChunkEvent {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     @NotNull @ImmutableCollection
     private List<Populator> terrainPopulators;

--- a/src/main/java/cn/nukkit/event/level/ChunkUnloadEvent.java
+++ b/src/main/java/cn/nukkit/event/level/ChunkUnloadEvent.java
@@ -1,19 +1,12 @@
 package cn.nukkit.event.level;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.format.FullChunk;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ChunkUnloadEvent extends ChunkEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public ChunkUnloadEvent(FullChunk chunk) {
         super(chunk);

--- a/src/main/java/cn/nukkit/event/level/LevelInitEvent.java
+++ b/src/main/java/cn/nukkit/event/level/LevelInitEvent.java
@@ -1,18 +1,11 @@
 package cn.nukkit.event.level;
 
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.Level;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class LevelInitEvent extends LevelEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public LevelInitEvent(Level level) {
         super(level);

--- a/src/main/java/cn/nukkit/event/level/LevelLoadEvent.java
+++ b/src/main/java/cn/nukkit/event/level/LevelLoadEvent.java
@@ -1,18 +1,11 @@
 package cn.nukkit.event.level;
 
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.Level;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class LevelLoadEvent extends LevelEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public LevelLoadEvent(Level level) {
         super(level);

--- a/src/main/java/cn/nukkit/event/level/LevelSaveEvent.java
+++ b/src/main/java/cn/nukkit/event/level/LevelSaveEvent.java
@@ -1,18 +1,11 @@
 package cn.nukkit.event.level;
 
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.Level;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class LevelSaveEvent extends LevelEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public LevelSaveEvent(Level level) {
         super(level);

--- a/src/main/java/cn/nukkit/event/level/LevelUnloadEvent.java
+++ b/src/main/java/cn/nukkit/event/level/LevelUnloadEvent.java
@@ -1,19 +1,12 @@
 package cn.nukkit.event.level;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.Level;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class LevelUnloadEvent extends LevelEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public LevelUnloadEvent(Level level) {
         super(level);

--- a/src/main/java/cn/nukkit/event/level/SpawnChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/level/SpawnChangeEvent.java
@@ -1,6 +1,5 @@
 package cn.nukkit.event.level;
 
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.Position;
 
@@ -8,12 +7,6 @@ import cn.nukkit.level.Position;
  * @author MagicDroidX (Nukkit Project)
  */
 public class SpawnChangeEvent extends LevelEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Position previousSpawn;
 

--- a/src/main/java/cn/nukkit/event/level/StructureGrowEvent.java
+++ b/src/main/java/cn/nukkit/event/level/StructureGrowEvent.java
@@ -3,7 +3,6 @@ package cn.nukkit.event.level;
 import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import java.util.List;
 import java.util.Objects;
 
@@ -12,13 +11,6 @@ import java.util.Objects;
  */
 @Since("1.4.0.0-PN")
 public class StructureGrowEvent extends LevelEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    @Since("1.4.0.0-PN")
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Block block;
     private final List<Block> blocks;

--- a/src/main/java/cn/nukkit/event/level/ThunderChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/level/ThunderChangeEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.level;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.Level;
 
 /**
@@ -9,13 +8,7 @@ import cn.nukkit.level.Level;
  */
 public class ThunderChangeEvent extends WeatherEvent implements Cancellable {
 
-    private static final HandlerList handlers = new HandlerList();
-
     private final boolean to;
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public ThunderChangeEvent(Level level, boolean to) {
         super(level);

--- a/src/main/java/cn/nukkit/event/level/VibrationArriveEvent.java
+++ b/src/main/java/cn/nukkit/event/level/VibrationArriveEvent.java
@@ -2,18 +2,11 @@ package cn.nukkit.event.level;
 
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.vibration.VibrationListener;
 
 @PowerNukkitXOnly
 @Since("1.19.21-r3")
 public class VibrationArriveEvent extends VibrationEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected VibrationListener listener;
 

--- a/src/main/java/cn/nukkit/event/level/VibrationOccurEvent.java
+++ b/src/main/java/cn/nukkit/event/level/VibrationOccurEvent.java
@@ -2,17 +2,10 @@ package cn.nukkit.event.level;
 
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
-import cn.nukkit.event.HandlerList;
 
 @PowerNukkitXOnly
 @Since("1.19.21-r3")
 public class VibrationOccurEvent extends VibrationEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public VibrationOccurEvent(cn.nukkit.level.vibration.VibrationEvent vibrationEvent) {
         super(vibrationEvent);

--- a/src/main/java/cn/nukkit/event/level/WeatherChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/level/WeatherChangeEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.level;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.Level;
 
 /**
@@ -9,13 +8,7 @@ import cn.nukkit.level.Level;
  */
 public class WeatherChangeEvent extends WeatherEvent implements Cancellable {
 
-    private static final HandlerList handlers = new HandlerList();
-
     private final boolean to;
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public WeatherChangeEvent(Level level, boolean to) {
         super(level);

--- a/src/main/java/cn/nukkit/event/player/EntityFreezeEvent.java
+++ b/src/main/java/cn/nukkit/event/player/EntityFreezeEvent.java
@@ -4,19 +4,13 @@ import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.event.entity.EntityEvent;
 
 @PowerNukkitXOnly
 @Since("1.6.0.0-PNX")
 public class EntityFreezeEvent extends EntityEvent implements Cancellable {
+
     private final Entity entity;
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public EntityFreezeEvent(Entity human) {
         this.entity = human;

--- a/src/main/java/cn/nukkit/event/player/PlayerAchievementAwardedEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerAchievementAwardedEvent.java
@@ -1,15 +1,9 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 public class PlayerAchievementAwardedEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected final String achievement;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerAnimationEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerAnimationEvent.java
@@ -3,16 +3,10 @@ package cn.nukkit.event.player;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.network.protocol.AnimatePacket;
 import cn.nukkit.player.Player;
 
 public class PlayerAnimationEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final AnimatePacket.Action animationType;
     private final float rowingTime;

--- a/src/main/java/cn/nukkit/event/player/PlayerAsyncPreLoginEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerAsyncPreLoginEvent.java
@@ -5,7 +5,6 @@ import cn.nukkit.api.DeprecationDetails;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.entity.data.Skin;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 import cn.nukkit.utils.ClientChainData;
 import cn.nukkit.utils.LoginChainData;
@@ -21,12 +20,6 @@ import java.util.function.Consumer;
  * @author CreeperFace
  */
 public class PlayerAsyncPreLoginEvent extends PlayerEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final String name;
     private final UUID uuid;

--- a/src/main/java/cn/nukkit/event/player/PlayerBedEnterEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerBedEnterEvent.java
@@ -2,15 +2,9 @@ package cn.nukkit.event.player;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 public class PlayerBedEnterEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Block bed;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerBedLeaveEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerBedLeaveEvent.java
@@ -1,15 +1,9 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.block.Block;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 public class PlayerBedLeaveEvent extends PlayerEvent {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Block bed;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerBlockPickEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerBlockPickEvent.java
@@ -2,7 +2,6 @@ package cn.nukkit.event.player;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.player.Player;
 
@@ -10,12 +9,6 @@ import cn.nukkit.player.Player;
  * @author CreeperFace
  */
 public class PlayerBlockPickEvent extends PlayerEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Block blockClicked;
     private Item item;

--- a/src/main/java/cn/nukkit/event/player/PlayerBucketEmptyEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerBucketEmptyEvent.java
@@ -2,17 +2,11 @@ package cn.nukkit.event.player;
 
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.block.Block;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.player.Player;
 
 public class PlayerBucketEmptyEvent extends PlayerBucketEvent {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     @PowerNukkitOnly
     public PlayerBucketEmptyEvent(

--- a/src/main/java/cn/nukkit/event/player/PlayerBucketFillEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerBucketFillEvent.java
@@ -2,17 +2,11 @@ package cn.nukkit.event.player;
 
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.block.Block;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.player.Player;
 
 public class PlayerBucketFillEvent extends PlayerBucketEvent {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     @PowerNukkitOnly
     public PlayerBucketFillEvent(

--- a/src/main/java/cn/nukkit/event/player/PlayerChangeArmorStandEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerChangeArmorStandEvent.java
@@ -4,22 +4,16 @@ import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.player.Player;
 
 @PowerNukkitXOnly
 @Since("1.19.31-r1")
 public class PlayerChangeArmorStandEvent extends PlayerEvent implements Cancellable {
+
     private final Entity armorStand;
     private Item item;
     private final int slot;
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public PlayerChangeArmorStandEvent(Player player, Entity armorStand, Item item, int slot) {
         this.player = player;

--- a/src/main/java/cn/nukkit/event/player/PlayerChangeSkinEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerChangeSkinEvent.java
@@ -2,19 +2,12 @@ package cn.nukkit.event.player;
 
 import cn.nukkit.entity.data.Skin;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 /**
  * @author KCodeYT (Nukkit Project)
  */
 public class PlayerChangeSkinEvent extends PlayerEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Skin skin;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerChatEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerChatEvent.java
@@ -3,18 +3,12 @@ package cn.nukkit.event.player;
 import cn.nukkit.Server;
 import cn.nukkit.command.CommandSender;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.permission.Permissible;
 import cn.nukkit.player.Player;
 import java.util.HashSet;
 import java.util.Set;
 
 public class PlayerChatEvent extends PlayerMessageEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected String format;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerChunkRequestEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerChunkRequestEvent.java
@@ -1,16 +1,10 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.api.PowerNukkitXDifference;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 @PowerNukkitXDifference(info = "PlayerChunkRequestEvent can't be cancelled")
 public class PlayerChunkRequestEvent extends PlayerEvent {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final int chunkX;
     private final int chunkZ;

--- a/src/main/java/cn/nukkit/event/player/PlayerCommandPreprocessEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerCommandPreprocessEvent.java
@@ -1,15 +1,9 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 public class PlayerCommandPreprocessEvent extends PlayerMessageEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public PlayerCommandPreprocessEvent(Player player, String message) {
         this.player = player;

--- a/src/main/java/cn/nukkit/event/player/PlayerCreationEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerCreationEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Event;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.network.SourceInterface;
 import cn.nukkit.player.Player;
 import java.net.InetSocketAddress;
@@ -10,12 +9,6 @@ import java.net.InetSocketAddress;
  * @author MagicDroidX (Nukkit Project)
  */
 public class PlayerCreationEvent extends Event {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final SourceInterface interfaz;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerDeathEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerDeathEvent.java
@@ -4,7 +4,6 @@ import cn.nukkit.api.DeprecationDetails;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.event.entity.EntityDeathEvent;
 import cn.nukkit.item.Item;
 import cn.nukkit.lang.TextContainer;
@@ -12,11 +11,6 @@ import cn.nukkit.lang.TranslationContainer;
 import cn.nukkit.player.Player;
 
 public class PlayerDeathEvent extends EntityDeathEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private TextContainer deathMessage;
     private boolean keepInventory = false;

--- a/src/main/java/cn/nukkit/event/player/PlayerDialogRespondedEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerDialogRespondedEvent.java
@@ -2,15 +2,9 @@ package cn.nukkit.event.player;
 
 import cn.nukkit.dialog.response.FormResponseDialog;
 import cn.nukkit.dialog.window.FormWindowDialog;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 public class PlayerDialogRespondedEvent extends PlayerEvent {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected FormWindowDialog dialog;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerDropItemEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerDropItemEvent.java
@@ -1,16 +1,10 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.player.Player;
 
 public class PlayerDropItemEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Item drop;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerEatFoodEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerEatFoodEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.food.Food;
 import cn.nukkit.player.Player;
 
@@ -10,12 +9,8 @@ import cn.nukkit.player.Player;
  * @since 2016/1/14
  */
 public class PlayerEatFoodEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-    private Food food;
 
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
+    private Food food;
 
     public PlayerEatFoodEvent(Player player, Food food) {
         this.player = player;

--- a/src/main/java/cn/nukkit/event/player/PlayerEditBookEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerEditBookEvent.java
@@ -1,18 +1,11 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.network.protocol.BookEditPacket;
 import cn.nukkit.player.Player;
 
 public class PlayerEditBookEvent extends PlayerEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Item oldBook;
     private final BookEditPacket.Action action;

--- a/src/main/java/cn/nukkit/event/player/PlayerExperienceChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerExperienceChangeEvent.java
@@ -1,15 +1,9 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 public class PlayerExperienceChangeEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final int oldExp;
     private final int oldExpLevel;

--- a/src/main/java/cn/nukkit/event/player/PlayerFishEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerFishEvent.java
@@ -3,7 +3,6 @@ package cn.nukkit.event.player;
 import cn.nukkit.api.Since;
 import cn.nukkit.entity.item.EntityFishingHook;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.player.Player;
@@ -15,13 +14,6 @@ import cn.nukkit.player.Player;
  */
 @Since("1.5.0.0-PN")
 public class PlayerFishEvent extends PlayerEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    @Since("1.5.0.0-PN")
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final EntityFishingHook hook;
     private Item loot;

--- a/src/main/java/cn/nukkit/event/player/PlayerFoodLevelChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerFoodLevelChangeEvent.java
@@ -1,15 +1,9 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 public class PlayerFoodLevelChangeEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected int foodLevel;
     protected float foodSaturationLevel;

--- a/src/main/java/cn/nukkit/event/player/PlayerFormRespondedEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerFormRespondedEvent.java
@@ -1,17 +1,10 @@
 package cn.nukkit.event.player;
 
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.form.response.FormResponse;
 import cn.nukkit.form.window.FormWindow;
 import cn.nukkit.player.Player;
 
 public class PlayerFormRespondedEvent extends PlayerEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected int formID;
     protected FormWindow window;

--- a/src/main/java/cn/nukkit/event/player/PlayerGameModeChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerGameModeChangeEvent.java
@@ -1,16 +1,10 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.AdventureSettings;
 import cn.nukkit.player.Player;
 
 public class PlayerGameModeChangeEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected final int gamemode;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerInteractEntityEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerInteractEntityEvent.java
@@ -2,7 +2,6 @@ package cn.nukkit.event.player;
 
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.player.Player;
@@ -12,8 +11,6 @@ import cn.nukkit.player.Player;
  * @since 1. 1. 2017
  */
 public class PlayerInteractEntityEvent extends PlayerEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
 
     protected final Entity entity;
     protected final Item item;
@@ -36,9 +33,5 @@ public class PlayerInteractEntityEvent extends PlayerEvent implements Cancellabl
 
     public Vector3 getClickedPos() {
         return clickedPos;
-    }
-
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/event/player/PlayerInteractEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerInteractEvent.java
@@ -2,7 +2,6 @@ package cn.nukkit.event.player;
 
 import cn.nukkit.block.Block;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.level.Position;
 import cn.nukkit.math.BlockFace;
@@ -14,12 +13,6 @@ import org.jetbrains.annotations.Nullable;
  * @author MagicDroidX (Nukkit Project)
  */
 public class PlayerInteractEvent extends PlayerEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     @Nullable protected final Block blockTouched;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerInvalidMoveEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerInvalidMoveEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 /**
@@ -11,13 +10,7 @@ import cn.nukkit.player.Player;
  */
 public class PlayerInvalidMoveEvent extends PlayerEvent implements Cancellable {
 
-    private static final HandlerList handlers = new HandlerList();
-
     private boolean revert;
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public PlayerInvalidMoveEvent(Player player, boolean revert) {
         this.player = player;

--- a/src/main/java/cn/nukkit/event/player/PlayerItemConsumeEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerItemConsumeEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.player.Player;
 
@@ -9,11 +8,6 @@ import cn.nukkit.player.Player;
  * Called when a player eats something
  */
 public class PlayerItemConsumeEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Item item;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerItemHeldEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerItemHeldEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.player.Player;
 
@@ -9,12 +8,6 @@ import cn.nukkit.player.Player;
  * @author MagicDroidX (Nukkit Project)
  */
 public class PlayerItemHeldEvent extends PlayerEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Item item;
     private final int hotbarSlot;

--- a/src/main/java/cn/nukkit/event/player/PlayerJoinEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerJoinEvent.java
@@ -1,15 +1,9 @@
 package cn.nukkit.event.player;
 
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.lang.TextContainer;
 import cn.nukkit.player.Player;
 
 public class PlayerJoinEvent extends PlayerEvent {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected TextContainer joinMessage;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerJumpEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerJumpEvent.java
@@ -1,14 +1,8 @@
 package cn.nukkit.event.player;
 
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 public class PlayerJumpEvent extends PlayerEvent {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public PlayerJumpEvent(Player player) {
         this.player = player;

--- a/src/main/java/cn/nukkit/event/player/PlayerKickEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerKickEvent.java
@@ -3,12 +3,10 @@ package cn.nukkit.event.player;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.lang.TextContainer;
 import cn.nukkit.player.Player;
 
 public class PlayerKickEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
 
     public enum Reason {
         NEW_CONNECTION,
@@ -29,10 +27,6 @@ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
         public String toString() {
             return this.name();
         }
-    }
-
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 
     protected TextContainer quitMessage;

--- a/src/main/java/cn/nukkit/event/player/PlayerLocallyInitializedEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerLocallyInitializedEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.api.Since;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 /**
@@ -9,12 +8,6 @@ import cn.nukkit.player.Player;
  */
 @Since("1.4.0.0-PN")
 public class PlayerLocallyInitializedEvent extends PlayerEvent {
-    private static final HandlerList handlers = new HandlerList();
-
-    @Since("1.4.0.0-PN")
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     @Since("1.4.0.0-PN")
     public PlayerLocallyInitializedEvent(Player player) {

--- a/src/main/java/cn/nukkit/event/player/PlayerLoginEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerLoginEvent.java
@@ -1,15 +1,9 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 public class PlayerLoginEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected String kickMessage;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerMapInfoRequestEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerMapInfoRequestEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
 import cn.nukkit.player.Player;
 
@@ -10,8 +9,6 @@ import cn.nukkit.player.Player;
  * @since 18.3.2017
  */
 public class PlayerMapInfoRequestEvent extends PlayerEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
 
     private Item item;
 
@@ -22,9 +19,5 @@ public class PlayerMapInfoRequestEvent extends PlayerEvent implements Cancellabl
 
     public Item getMap() {
         return item;
-    }
-
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/event/player/PlayerMouseOverEntityEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerMouseOverEntityEvent.java
@@ -1,15 +1,9 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.entity.Entity;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 public class PlayerMouseOverEntityEvent extends PlayerEvent {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Entity entity;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerMoveEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerMoveEvent.java
@@ -1,16 +1,10 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.Location;
 import cn.nukkit.player.Player;
 
 public class PlayerMoveEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private Location from;
     private Location to;
@@ -53,7 +47,7 @@ public class PlayerMoveEvent extends PlayerEvent implements Cancellable {
     }
 
     @Override
-    public void setCancelled() {
-        super.setCancelled();
+    public void cancel() {
+        super.cancel();
     }
 }

--- a/src/main/java/cn/nukkit/event/player/PlayerPreLoginEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerPreLoginEvent.java
@@ -1,18 +1,12 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 /**
  * Called when the player logs in, before things have been set up
  */
 public class PlayerPreLoginEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected String kickMessage;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerQuitEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerQuitEvent.java
@@ -1,15 +1,9 @@
 package cn.nukkit.event.player;
 
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.lang.TextContainer;
 import cn.nukkit.player.Player;
 
 public class PlayerQuitEvent extends PlayerEvent {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected TextContainer quitMessage;
     protected boolean autoSave = true;

--- a/src/main/java/cn/nukkit/event/player/PlayerRespawnEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerRespawnEvent.java
@@ -2,16 +2,10 @@ package cn.nukkit.event.player;
 
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.Position;
 import cn.nukkit.player.Player;
 
 public class PlayerRespawnEvent extends PlayerEvent {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private Position position; // Respawn Position
 

--- a/src/main/java/cn/nukkit/event/player/PlayerServerSettingsRequestEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerServerSettingsRequestEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.form.window.FormWindow;
 import cn.nukkit.player.Player;
 import java.util.Map;
@@ -10,12 +9,6 @@ import java.util.Map;
  * @author CreeperFace
  */
 public class PlayerServerSettingsRequestEvent extends PlayerEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private Map<Integer, FormWindow> settings;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerSettingsRespondedEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerSettingsRespondedEvent.java
@@ -1,18 +1,11 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.form.response.FormResponse;
 import cn.nukkit.form.window.FormWindow;
 import cn.nukkit.player.Player;
 
 public class PlayerSettingsRespondedEvent extends PlayerEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected int formID;
     protected FormWindow window;
@@ -52,7 +45,7 @@ public class PlayerSettingsRespondedEvent extends PlayerEvent implements Cancell
     }
 
     @Override
-    public void setCancelled() {
-        super.setCancelled();
+    public void cancel() {
+        super.cancel();
     }
 }

--- a/src/main/java/cn/nukkit/event/player/PlayerShowCreditsEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerShowCreditsEvent.java
@@ -1,19 +1,12 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 /**
  * @author GoodLucky777
  */
 public class PlayerShowCreditsEvent extends PlayerEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public PlayerShowCreditsEvent(Player player) {
         this.player = player;

--- a/src/main/java/cn/nukkit/event/player/PlayerTeleportEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerTeleportEvent.java
@@ -4,7 +4,6 @@ import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.Location;
 import cn.nukkit.level.Position;
@@ -12,11 +11,6 @@ import cn.nukkit.math.Vector3;
 import cn.nukkit.player.Player;
 
 public class PlayerTeleportEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private TeleportCause cause;
     private Location from;

--- a/src/main/java/cn/nukkit/event/player/PlayerToggleFlightEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerToggleFlightEvent.java
@@ -1,15 +1,9 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 public class PlayerToggleFlightEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected final boolean isFlying;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerToggleGlideEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerToggleGlideEvent.java
@@ -1,15 +1,9 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 public class PlayerToggleGlideEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected final boolean isGliding;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerToggleSneakEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerToggleSneakEvent.java
@@ -1,15 +1,9 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 public class PlayerToggleSneakEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected final boolean isSneaking;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerToggleSpinAttackEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerToggleSpinAttackEvent.java
@@ -3,7 +3,6 @@ package cn.nukkit.event.player;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 /**
@@ -12,14 +11,6 @@ import cn.nukkit.player.Player;
 @PowerNukkitOnly
 @Since("1.4.0.0-PN")
 public class PlayerToggleSpinAttackEvent extends PlayerEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    @PowerNukkitOnly
-    @Since("1.4.0.0-PN")
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final boolean isSpinAttacking;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerToggleSprintEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerToggleSprintEvent.java
@@ -1,15 +1,9 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 public class PlayerToggleSprintEvent extends PlayerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     protected final boolean isSprinting;
 

--- a/src/main/java/cn/nukkit/event/player/PlayerToggleSwimEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerToggleSwimEvent.java
@@ -1,19 +1,12 @@
 package cn.nukkit.event.player;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 /**
  * @author CreeperFace
  */
 public class PlayerToggleSwimEvent extends PlayerEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final boolean isSwimming;
 

--- a/src/main/java/cn/nukkit/event/plugin/PluginEvent.java
+++ b/src/main/java/cn/nukkit/event/plugin/PluginEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.plugin;
 
 import cn.nukkit.event.Event;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.plugin.Plugin;
 
 /**
@@ -9,16 +8,10 @@ import cn.nukkit.plugin.Plugin;
  */
 public class PluginEvent extends Event {
 
-    private static final HandlerList handlers = new HandlerList();
-
     private final Plugin plugin;
 
     public PluginEvent(Plugin plugin) {
         this.plugin = plugin;
-    }
-
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 
     public Plugin getPlugin() {

--- a/src/main/java/cn/nukkit/event/potion/PotionApplyEvent.java
+++ b/src/main/java/cn/nukkit/event/potion/PotionApplyEvent.java
@@ -2,7 +2,6 @@ package cn.nukkit.event.potion;
 
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.potion.Effect;
 import cn.nukkit.potion.Potion;
 
@@ -11,12 +10,6 @@ import cn.nukkit.potion.Potion;
  * @since 2016/1/12
  */
 public class PotionApplyEvent extends PotionEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private Effect applyEffect;
 

--- a/src/main/java/cn/nukkit/event/potion/PotionCollideEvent.java
+++ b/src/main/java/cn/nukkit/event/potion/PotionCollideEvent.java
@@ -2,7 +2,6 @@ package cn.nukkit.event.potion;
 
 import cn.nukkit.entity.item.EntityPotion;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.potion.Potion;
 
 /**
@@ -10,12 +9,6 @@ import cn.nukkit.potion.Potion;
  * @since 2016/1/12
  */
 public class PotionCollideEvent extends PotionEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final EntityPotion thrownPotion;
 

--- a/src/main/java/cn/nukkit/event/redstone/RedstoneUpdateEvent.java
+++ b/src/main/java/cn/nukkit/event/redstone/RedstoneUpdateEvent.java
@@ -1,19 +1,12 @@
 package cn.nukkit.event.redstone;
 
 import cn.nukkit.block.Block;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.event.block.BlockUpdateEvent;
 
 /**
  * @author Angelic47 (Nukkit Project)
  */
 public class RedstoneUpdateEvent extends BlockUpdateEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public RedstoneUpdateEvent(Block source) {
         super(source);

--- a/src/main/java/cn/nukkit/event/scoreboard/ScoreboardEvent.java
+++ b/src/main/java/cn/nukkit/event/scoreboard/ScoreboardEvent.java
@@ -4,7 +4,6 @@ import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.event.Cancellable;
 import cn.nukkit.event.Event;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.scoreboard.scoreboard.IScoreboard;
 import lombok.Getter;
 
@@ -16,16 +15,10 @@ import lombok.Getter;
 @Getter
 public abstract class ScoreboardEvent extends Event implements Cancellable {
 
-    private static final HandlerList handlers = new HandlerList();
-
     private final IScoreboard scoreboard;
 
     public ScoreboardEvent(IScoreboard scoreboard) {
         this.scoreboard = scoreboard;
-    }
-
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 
     public IScoreboard getScoreboard() {

--- a/src/main/java/cn/nukkit/event/scoreboard/ScoreboardLineChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/scoreboard/ScoreboardLineChangeEvent.java
@@ -2,7 +2,6 @@ package cn.nukkit.event.scoreboard;
 
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.scoreboard.scoreboard.IScoreboard;
 import cn.nukkit.scoreboard.scoreboard.IScoreboardLine;
 import javax.annotation.Nullable;
@@ -15,17 +14,11 @@ import lombok.Setter;
 @Setter
 public class ScoreboardLineChangeEvent extends ScoreboardEvent {
 
-    private static final HandlerList handlers = new HandlerList();
-
     @Nullable private final IScoreboardLine line;
 
     private int newValue;
     private int oldValue;
     private final ActionType actionType;
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public ScoreboardLineChangeEvent(
             IScoreboard scoreboard, @Nullable IScoreboardLine line, int newValue, int oldValue) {

--- a/src/main/java/cn/nukkit/event/scoreboard/ScoreboardObjectiveChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/scoreboard/ScoreboardObjectiveChangeEvent.java
@@ -2,18 +2,11 @@ package cn.nukkit.event.scoreboard;
 
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.scoreboard.scoreboard.IScoreboard;
 
 @PowerNukkitXOnly
 @Since("1.19.30-r2")
 public class ScoreboardObjectiveChangeEvent extends ScoreboardEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final ActionType actionType;
 

--- a/src/main/java/cn/nukkit/event/server/BatchPacketsEvent.java
+++ b/src/main/java/cn/nukkit/event/server/BatchPacketsEvent.java
@@ -1,17 +1,10 @@
 package cn.nukkit.event.server;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.network.protocol.DataPacket;
 import cn.nukkit.player.Player;
 
 public class BatchPacketsEvent extends ServerEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private Player[] players;
     private DataPacket[] packets;

--- a/src/main/java/cn/nukkit/event/server/ConsoleCommandOutputEvent.java
+++ b/src/main/java/cn/nukkit/event/server/ConsoleCommandOutputEvent.java
@@ -4,12 +4,11 @@ import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.command.CommandSender;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 @PowerNukkitXOnly
 @Since("1.19.60-r1")
 public class ConsoleCommandOutputEvent extends ServerEvent implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
+
     protected final CommandSender sender;
     protected String message;
 
@@ -28,9 +27,5 @@ public class ConsoleCommandOutputEvent extends ServerEvent implements Cancellabl
 
     public void setMessage(String message) {
         this.message = message;
-    }
-
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/event/server/DataPacketReceiveEvent.java
+++ b/src/main/java/cn/nukkit/event/server/DataPacketReceiveEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.server;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.network.protocol.DataPacket;
 import cn.nukkit.player.Player;
 
@@ -9,8 +8,6 @@ import cn.nukkit.player.Player;
  * @author MagicDroidX (Nukkit Project)
  */
 public class DataPacketReceiveEvent extends ServerEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
 
     private final DataPacket packet;
     private final Player player;
@@ -26,9 +23,5 @@ public class DataPacketReceiveEvent extends ServerEvent implements Cancellable {
 
     public Player getPlayer() {
         return player;
-    }
-
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/event/server/DataPacketSendEvent.java
+++ b/src/main/java/cn/nukkit/event/server/DataPacketSendEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.server;
 
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.network.protocol.DataPacket;
 import cn.nukkit.player.Player;
 
@@ -9,12 +8,6 @@ import cn.nukkit.player.Player;
  * @author MagicDroidX (Nukkit Project)
  */
 public class DataPacketSendEvent extends ServerEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final DataPacket packet;
     private final Player player;

--- a/src/main/java/cn/nukkit/event/server/PlayerDataSerializeEvent.java
+++ b/src/main/java/cn/nukkit/event/server/PlayerDataSerializeEvent.java
@@ -1,6 +1,5 @@
 package cn.nukkit.event.server;
 
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.utils.PlayerDataSerializer;
 import com.google.common.base.Preconditions;
 import java.util.Optional;
@@ -8,7 +7,6 @@ import java.util.UUID;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class PlayerDataSerializeEvent extends ServerEvent {
-    private static HandlerList handlers = new HandlerList();
 
     private final Optional<String> name;
     private final Optional<UUID> uuid;
@@ -41,9 +39,5 @@ public class PlayerDataSerializeEvent extends ServerEvent {
 
     public void setSerializer(PlayerDataSerializer serializer) {
         this.serializer = Preconditions.checkNotNull(serializer, "serializer");
-    }
-
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/event/server/QueryRegenerateEvent.java
+++ b/src/main/java/cn/nukkit/event/server/QueryRegenerateEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.server;
 
 import cn.nukkit.Server;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.nbt.stream.FastByteArrayOutputStream;
 import cn.nukkit.player.Player;
 import cn.nukkit.plugin.Plugin;
@@ -18,12 +17,6 @@ import java.util.Map;
  */
 public class QueryRegenerateEvent extends ServerEvent {
     // alot todo
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private static final String GAME_ID = "MINECRAFTPE";
 

--- a/src/main/java/cn/nukkit/event/server/RemoteServerCommandEvent.java
+++ b/src/main/java/cn/nukkit/event/server/RemoteServerCommandEvent.java
@@ -1,7 +1,6 @@
 package cn.nukkit.event.server;
 
 import cn.nukkit.command.CommandSender;
-import cn.nukkit.event.HandlerList;
 
 /**
  * Called when an RCON command is executed.
@@ -9,11 +8,6 @@ import cn.nukkit.event.HandlerList;
  * @author Tee7even
  */
 public class RemoteServerCommandEvent extends ServerCommandEvent {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public RemoteServerCommandEvent(CommandSender sender, String command) {
         super(sender, command);

--- a/src/main/java/cn/nukkit/event/server/ServerCommandEvent.java
+++ b/src/main/java/cn/nukkit/event/server/ServerCommandEvent.java
@@ -2,14 +2,11 @@ package cn.nukkit.event.server;
 
 import cn.nukkit.command.CommandSender;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ServerCommandEvent extends ServerEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
 
     protected String command;
 
@@ -30,9 +27,5 @@ public class ServerCommandEvent extends ServerEvent implements Cancellable {
 
     public void setCommand(String command) {
         this.command = command;
-    }
-
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/event/server/ServerStartedEvent.java
+++ b/src/main/java/cn/nukkit/event/server/ServerStartedEvent.java
@@ -1,14 +1,6 @@
 package cn.nukkit.event.server;
 
-import cn.nukkit.event.HandlerList;
-
 /**
  * 服务器启动完毕后会触发，注意reload也会触发
  */
-public class ServerStartedEvent extends ServerEvent {
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
-}
+public class ServerStartedEvent extends ServerEvent {}

--- a/src/main/java/cn/nukkit/event/server/ServerStopEvent.java
+++ b/src/main/java/cn/nukkit/event/server/ServerStopEvent.java
@@ -1,15 +1,6 @@
 package cn.nukkit.event.server;
 
-import cn.nukkit.event.HandlerList;
-
 /**
  * @author NycuRO (NukkitX Project)
  */
-public class ServerStopEvent extends ServerEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
-}
+public class ServerStopEvent extends ServerEvent {}

--- a/src/main/java/cn/nukkit/event/vehicle/EntityEnterVehicleEvent.java
+++ b/src/main/java/cn/nukkit/event/vehicle/EntityEnterVehicleEvent.java
@@ -2,16 +2,9 @@ package cn.nukkit.event.vehicle;
 
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 public class EntityEnterVehicleEvent extends VehicleEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final cn.nukkit.entity.Entity riding;
 

--- a/src/main/java/cn/nukkit/event/vehicle/EntityExitVehicleEvent.java
+++ b/src/main/java/cn/nukkit/event/vehicle/EntityExitVehicleEvent.java
@@ -2,16 +2,9 @@ package cn.nukkit.event.vehicle;
 
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.player.Player;
 
 public class EntityExitVehicleEvent extends VehicleEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final cn.nukkit.entity.Entity riding;
 

--- a/src/main/java/cn/nukkit/event/vehicle/VehicleCreateEvent.java
+++ b/src/main/java/cn/nukkit/event/vehicle/VehicleCreateEvent.java
@@ -2,15 +2,8 @@ package cn.nukkit.event.vehicle;
 
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 public class VehicleCreateEvent extends VehicleEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public VehicleCreateEvent(Entity vehicle) {
         super(vehicle);

--- a/src/main/java/cn/nukkit/event/vehicle/VehicleDamageByEntityEvent.java
+++ b/src/main/java/cn/nukkit/event/vehicle/VehicleDamageByEntityEvent.java
@@ -4,7 +4,6 @@ import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.entity.item.EntityVehicle;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * Is called when an entity damages a vehicle
@@ -14,8 +13,6 @@ import cn.nukkit.event.HandlerList;
  */
 @PowerNukkitOnly
 public final class VehicleDamageByEntityEvent extends VehicleDamageEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
 
     private final Entity attacker;
 
@@ -31,11 +28,6 @@ public final class VehicleDamageByEntityEvent extends VehicleDamageEvent impleme
         super(vehicle, damage);
 
         this.attacker = attacker;
-    }
-
-    @PowerNukkitOnly
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 
     /**

--- a/src/main/java/cn/nukkit/event/vehicle/VehicleDamageEvent.java
+++ b/src/main/java/cn/nukkit/event/vehicle/VehicleDamageEvent.java
@@ -3,14 +3,11 @@ package cn.nukkit.event.vehicle;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.entity.item.EntityVehicle;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * Is called when an entity takes damage
  */
 public class VehicleDamageEvent extends VehicleEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
 
     private double damage;
 
@@ -25,10 +22,6 @@ public class VehicleDamageEvent extends VehicleEvent implements Cancellable {
         super(vehicle);
 
         this.damage = damage;
-    }
-
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 
     /**

--- a/src/main/java/cn/nukkit/event/vehicle/VehicleDestroyByEntityEvent.java
+++ b/src/main/java/cn/nukkit/event/vehicle/VehicleDestroyByEntityEvent.java
@@ -3,7 +3,6 @@ package cn.nukkit.event.vehicle;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * Is called when an entity destroyed a vehicle
@@ -13,8 +12,6 @@ import cn.nukkit.event.HandlerList;
  */
 @PowerNukkitOnly
 public final class VehicleDestroyByEntityEvent extends VehicleDestroyEvent implements Cancellable {
-
-    private static final HandlerList HANDLER_LIST = new HandlerList();
 
     private final Entity destroyer;
 
@@ -29,11 +26,6 @@ public final class VehicleDestroyByEntityEvent extends VehicleDestroyEvent imple
         super(vehicle);
 
         this.destroyer = destroyer;
-    }
-
-    @PowerNukkitOnly
-    public static HandlerList getHandlers() {
-        return HANDLER_LIST;
     }
 
     /**

--- a/src/main/java/cn/nukkit/event/vehicle/VehicleDestroyEvent.java
+++ b/src/main/java/cn/nukkit/event/vehicle/VehicleDestroyEvent.java
@@ -3,14 +3,11 @@ package cn.nukkit.event.vehicle;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 
 /**
  * Is called when an vehicle gets destroyed
  */
 public class VehicleDestroyEvent extends VehicleEvent implements Cancellable {
-
-    private static final HandlerList handlers = new HandlerList();
 
     /**
      * Constructor for the VehicleDestroyEvent
@@ -20,9 +17,5 @@ public class VehicleDestroyEvent extends VehicleEvent implements Cancellable {
     @PowerNukkitOnly
     public VehicleDestroyEvent(final Entity vehicle) {
         super(vehicle);
-    }
-
-    public static HandlerList getHandlers() {
-        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/event/vehicle/VehicleMoveEvent.java
+++ b/src/main/java/cn/nukkit/event/vehicle/VehicleMoveEvent.java
@@ -1,16 +1,9 @@
 package cn.nukkit.event.vehicle;
 
 import cn.nukkit.entity.Entity;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.level.Location;
 
 public class VehicleMoveEvent extends VehicleEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     private final Location from;
     private final Location to;

--- a/src/main/java/cn/nukkit/event/vehicle/VehicleUpdateEvent.java
+++ b/src/main/java/cn/nukkit/event/vehicle/VehicleUpdateEvent.java
@@ -1,15 +1,8 @@
 package cn.nukkit.event.vehicle;
 
 import cn.nukkit.entity.Entity;
-import cn.nukkit.event.HandlerList;
 
 public class VehicleUpdateEvent extends VehicleEvent {
-
-    private static final HandlerList handlers = new HandlerList();
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public VehicleUpdateEvent(Entity vehicle) {
         super(vehicle);

--- a/src/main/java/cn/nukkit/event/weather/LightningStrikeEvent.java
+++ b/src/main/java/cn/nukkit/event/weather/LightningStrikeEvent.java
@@ -2,7 +2,6 @@ package cn.nukkit.event.weather;
 
 import cn.nukkit.entity.weather.EntityLightningStrike;
 import cn.nukkit.event.Cancellable;
-import cn.nukkit.event.HandlerList;
 import cn.nukkit.event.level.WeatherEvent;
 import cn.nukkit.level.Level;
 
@@ -11,12 +10,7 @@ import cn.nukkit.level.Level;
  */
 public class LightningStrikeEvent extends WeatherEvent implements Cancellable {
 
-    private static final HandlerList handlers = new HandlerList();
     private final EntityLightningStrike bolt;
-
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
 
     public LightningStrikeEvent(Level level, final EntityLightningStrike bolt) {
         super(level);

--- a/src/main/java/cn/nukkit/inventory/BaseInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BaseInventory.java
@@ -1,6 +1,5 @@
 package cn.nukkit.inventory;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.PowerNukkitXDifference;
 import cn.nukkit.api.PowerNukkitXOnly;
@@ -173,15 +172,15 @@ public abstract class BaseInventory implements Inventory {
 
         InventoryHolder holder = this.getHolder();
         if (holder instanceof Entity) {
-            EntityInventoryChangeEvent ev =
+            EntityInventoryChangeEvent event =
                     new EntityInventoryChangeEvent((Entity) holder, this.getItem(index), item, index);
-            Server.getInstance().getPluginManager().callEvent(ev);
-            if (ev.isCancelled()) {
+            event.call();
+            if (event.isCancelled()) {
                 this.sendSlot(index, this.getViewers());
                 return false;
             }
 
-            item = ev.getNewItem();
+            item = event.getNewItem();
         }
 
         if (holder instanceof BlockEntity) {
@@ -415,13 +414,13 @@ public abstract class BaseInventory implements Inventory {
             Item old = this.slots.get(index);
             InventoryHolder holder = this.getHolder();
             if (holder instanceof Entity) {
-                EntityInventoryChangeEvent ev = new EntityInventoryChangeEvent((Entity) holder, old, item, index);
-                Server.getInstance().getPluginManager().callEvent(ev);
-                if (ev.isCancelled()) {
+                EntityInventoryChangeEvent event = new EntityInventoryChangeEvent((Entity) holder, old, item, index);
+                event.call();
+                if (event.isCancelled()) {
                     this.sendSlot(index, this.getViewers());
                     return false;
                 }
-                item = ev.getNewItem();
+                item = event.getNewItem();
             }
 
             if (item.getId() != Item.AIR) {
@@ -461,9 +460,9 @@ public abstract class BaseInventory implements Inventory {
     @Override
     public boolean open(Player who) {
         // if (this.viewers.contains(who)) return false;
-        InventoryOpenEvent ev = new InventoryOpenEvent(this, who);
-        who.getServer().getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        InventoryOpenEvent event = new InventoryOpenEvent(this, who);
+        event.call();
+        if (event.isCancelled()) {
             return false;
         }
         this.onOpen(who);

--- a/src/main/java/cn/nukkit/inventory/ChestInventory.java
+++ b/src/main/java/cn/nukkit/inventory/ChestInventory.java
@@ -52,7 +52,7 @@ public class ChestInventory extends ContainerInventory {
         try {
             if (this.getHolder().getBlock() instanceof BlockTrappedChest trappedChest) {
                 RedstoneUpdateEvent event = new RedstoneUpdateEvent(trappedChest);
-                this.getHolder().level.getServer().getPluginManager().callEvent(event);
+                event.call();
                 if (!event.isCancelled()) {
                     RedstoneComponent.updateAllAroundRedstone(this.getHolder());
                 }
@@ -86,7 +86,7 @@ public class ChestInventory extends ContainerInventory {
         try {
             if (this.getHolder().getBlock() instanceof BlockTrappedChest trappedChest) {
                 RedstoneUpdateEvent event = new RedstoneUpdateEvent(trappedChest);
-                this.getHolder().level.getServer().getPluginManager().callEvent(event);
+                event.call();
                 if (!event.isCancelled()) {
                     RedstoneComponent.updateAllAroundRedstone(this.getHolder());
                 }

--- a/src/main/java/cn/nukkit/inventory/CommandBlockInventory.java
+++ b/src/main/java/cn/nukkit/inventory/CommandBlockInventory.java
@@ -183,9 +183,10 @@ public class CommandBlockInventory implements Inventory {
 
     @Override
     public boolean open(Player who) {
-        InventoryOpenEvent ev = new InventoryOpenEvent(this, who);
-        who.getServer().getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        InventoryOpenEvent event = new InventoryOpenEvent(this, who);
+        event.call();
+
+        if (event.isCancelled()) {
             return false;
         }
         this.onOpen(who);

--- a/src/main/java/cn/nukkit/inventory/FakeBlockUIComponent.java
+++ b/src/main/java/cn/nukkit/inventory/FakeBlockUIComponent.java
@@ -32,9 +32,9 @@ public class FakeBlockUIComponent extends PlayerUIComponent {
 
     @Override
     public boolean open(Player who) {
-        InventoryOpenEvent ev = new InventoryOpenEvent(this, who);
-        who.getServer().getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        InventoryOpenEvent event = new InventoryOpenEvent(this, who);
+        event.call();
+        if (event.isCancelled()) {
             return false;
         }
         this.onOpen(who);
@@ -44,8 +44,8 @@ public class FakeBlockUIComponent extends PlayerUIComponent {
 
     @Override
     public void close(Player who) {
-        InventoryCloseEvent ev = new InventoryCloseEvent(this, who);
-        who.getServer().getPluginManager().callEvent(ev);
+        InventoryCloseEvent event = new InventoryCloseEvent(this, who);
+        event.call();
 
         this.onClose(who);
     }

--- a/src/main/java/cn/nukkit/inventory/FakeHumanInventory.java
+++ b/src/main/java/cn/nukkit/inventory/FakeHumanInventory.java
@@ -1,6 +1,5 @@
 package cn.nukkit.inventory;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
@@ -258,22 +257,23 @@ public class FakeHumanInventory extends BaseInventory {
         }
         // Armor change
         if (!ignoreArmorEvents && index >= this.getSize()) {
-            EntityArmorChangeEvent ev = new EntityArmorChangeEvent(this.getHolder(), this.getItem(index), item, index);
-            Server.getInstance().getPluginManager().callEvent(ev);
-            if (ev.isCancelled() && this.getHolder() != null) {
+            EntityArmorChangeEvent event =
+                    new EntityArmorChangeEvent(this.getHolder(), this.getItem(index), item, index);
+            event.call();
+            if (event.isCancelled() && this.getHolder() != null) {
                 this.sendArmorSlot(index, this.getHolder().getViewers().values());
                 return false;
             }
-            item = ev.getNewItem();
+            item = event.getNewItem();
         } else {
-            EntityInventoryChangeEvent ev =
+            EntityInventoryChangeEvent event =
                     new EntityInventoryChangeEvent(this.getHolder(), this.getItem(index), item, index);
-            Server.getInstance().getPluginManager().callEvent(ev);
-            if (ev.isCancelled()) {
+            event.call();
+            if (event.isCancelled()) {
                 this.sendSlot(index, this.getViewers());
                 return false;
             }
-            item = ev.getNewItem();
+            item = event.getNewItem();
         }
         Item old = this.getItem(index);
         this.slots.put(index, item.clone());
@@ -287,9 +287,9 @@ public class FakeHumanInventory extends BaseInventory {
             Item item = new ItemBlock(Block.get(BlockID.AIR), null, 0);
             Item old = this.slots.get(index);
             if (index >= this.getSize() && index < this.size) {
-                EntityArmorChangeEvent ev = new EntityArmorChangeEvent(this.getHolder(), old, item, index);
-                Server.getInstance().getPluginManager().callEvent(ev);
-                if (ev.isCancelled()) {
+                EntityArmorChangeEvent event = new EntityArmorChangeEvent(this.getHolder(), old, item, index);
+                event.call();
+                if (event.isCancelled()) {
                     if (index >= this.size) {
                         this.sendArmorSlot(index, this.getViewers());
                     } else {
@@ -297,11 +297,11 @@ public class FakeHumanInventory extends BaseInventory {
                     }
                     return false;
                 }
-                item = ev.getNewItem();
+                item = event.getNewItem();
             } else {
-                EntityInventoryChangeEvent ev = new EntityInventoryChangeEvent(this.getHolder(), old, item, index);
-                Server.getInstance().getPluginManager().callEvent(ev);
-                if (ev.isCancelled()) {
+                EntityInventoryChangeEvent event = new EntityInventoryChangeEvent(this.getHolder(), old, item, index);
+                event.call();
+                if (event.isCancelled()) {
                     if (index >= this.size) {
                         this.sendArmorSlot(index, this.getViewers());
                     } else {
@@ -309,7 +309,7 @@ public class FakeHumanInventory extends BaseInventory {
                     }
                     return false;
                 }
-                item = ev.getNewItem();
+                item = event.getNewItem();
             }
 
             if (item.getId() != Item.AIR) {

--- a/src/main/java/cn/nukkit/inventory/PlayerInventory.java
+++ b/src/main/java/cn/nukkit/inventory/PlayerInventory.java
@@ -1,6 +1,5 @@
 package cn.nukkit.inventory;
 
-import cn.nukkit.Server;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockID;
 import cn.nukkit.entity.EntityHuman;
@@ -66,10 +65,10 @@ public class PlayerInventory extends BaseInventory {
 
         if (this.getHolder() instanceof Player) {
             Player player = (Player) this.getHolder();
-            PlayerItemHeldEvent ev = new PlayerItemHeldEvent(player, this.getItem(slot), slot);
-            this.getHolder().getLevel().getServer().getPluginManager().callEvent(ev);
+            PlayerItemHeldEvent event = new PlayerItemHeldEvent(player, this.getItem(slot), slot);
+            event.call();
 
-            if (ev.isCancelled()) {
+            if (event.isCancelled()) {
                 this.sendContents(this.getViewers());
                 return false;
             }
@@ -260,22 +259,23 @@ public class PlayerInventory extends BaseInventory {
 
         // Armor change
         if (!ignoreArmorEvents && index >= this.getSize()) {
-            EntityArmorChangeEvent ev = new EntityArmorChangeEvent(this.getHolder(), this.getItem(index), item, index);
-            Server.getInstance().getPluginManager().callEvent(ev);
-            if (ev.isCancelled() && this.getHolder() != null) {
+            EntityArmorChangeEvent event =
+                    new EntityArmorChangeEvent(this.getHolder(), this.getItem(index), item, index);
+            event.call();
+            if (event.isCancelled() && this.getHolder() != null) {
                 this.sendArmorSlot(index, this.getViewers());
                 return false;
             }
-            item = ev.getNewItem();
+            item = event.getNewItem();
         } else {
-            EntityInventoryChangeEvent ev =
+            EntityInventoryChangeEvent event =
                     new EntityInventoryChangeEvent(this.getHolder(), this.getItem(index), item, index);
-            Server.getInstance().getPluginManager().callEvent(ev);
-            if (ev.isCancelled()) {
+            event.call();
+            if (event.isCancelled()) {
                 this.sendSlot(index, this.getViewers());
                 return false;
             }
-            item = ev.getNewItem();
+            item = event.getNewItem();
         }
         Item old = this.getItem(index);
         this.slots.put(index, item.clone());
@@ -289,9 +289,9 @@ public class PlayerInventory extends BaseInventory {
             Item item = new ItemBlock(Block.get(BlockID.AIR), null, 0);
             Item old = this.slots.get(index);
             if (index >= this.getSize() && index < this.size) {
-                EntityArmorChangeEvent ev = new EntityArmorChangeEvent(this.getHolder(), old, item, index);
-                Server.getInstance().getPluginManager().callEvent(ev);
-                if (ev.isCancelled()) {
+                EntityArmorChangeEvent event = new EntityArmorChangeEvent(this.getHolder(), old, item, index);
+                event.call();
+                if (event.isCancelled()) {
                     if (index >= this.size) {
                         this.sendArmorSlot(index, this.getViewers());
                     } else {
@@ -299,11 +299,11 @@ public class PlayerInventory extends BaseInventory {
                     }
                     return false;
                 }
-                item = ev.getNewItem();
+                item = event.getNewItem();
             } else {
-                EntityInventoryChangeEvent ev = new EntityInventoryChangeEvent(this.getHolder(), old, item, index);
-                Server.getInstance().getPluginManager().callEvent(ev);
-                if (ev.isCancelled()) {
+                EntityInventoryChangeEvent event = new EntityInventoryChangeEvent(this.getHolder(), old, item, index);
+                event.call();
+                if (event.isCancelled()) {
                     if (index >= this.size) {
                         this.sendArmorSlot(index, this.getViewers());
                     } else {
@@ -311,7 +311,7 @@ public class PlayerInventory extends BaseInventory {
                     }
                     return false;
                 }
-                item = ev.getNewItem();
+                item = event.getNewItem();
             }
 
             if (item.getId() != Item.AIR) {

--- a/src/main/java/cn/nukkit/inventory/StructBlockInventory.java
+++ b/src/main/java/cn/nukkit/inventory/StructBlockInventory.java
@@ -180,9 +180,10 @@ public class StructBlockInventory implements Inventory {
 
     @Override
     public boolean open(Player who) {
-        InventoryOpenEvent ev = new InventoryOpenEvent(this, who);
-        who.getServer().getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        InventoryOpenEvent event = new InventoryOpenEvent(this, who);
+        event.call();
+
+        if (event.isCancelled()) {
             return false;
         }
         this.onOpen(who);

--- a/src/main/java/cn/nukkit/inventory/transaction/CraftingTransaction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/CraftingTransaction.java
@@ -218,10 +218,9 @@ public class CraftingTransaction extends InventoryTransaction {
 
     @Override
     protected boolean callExecuteEvent() {
-        CraftItemEvent ev;
-
-        this.source.getServer().getPluginManager().callEvent(ev = new CraftItemEvent(this));
-        return !ev.isCancelled();
+        CraftItemEvent event = new CraftItemEvent(this);
+        event.call();
+        return !event.isCancelled();
     }
 
     @Override

--- a/src/main/java/cn/nukkit/inventory/transaction/EnchantTransaction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/EnchantTransaction.java
@@ -49,9 +49,9 @@ public class EnchantTransaction extends InventoryTransaction {
             return false;
         }
         EnchantInventory inv = (EnchantInventory) getSource().getWindowById(Player.ENCHANT_WINDOW_ID);
-        EnchantItemEvent ev = new EnchantItemEvent(inv, inputItem, outputItem, cost, source);
-        source.getServer().getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        EnchantItemEvent event = new EnchantItemEvent(inv, inputItem, outputItem, cost, source);
+        event.call();
+        if (event.isCancelled()) {
             source.removeAllWindows(false);
             this.sendInventories();
 
@@ -67,14 +67,14 @@ public class EnchantTransaction extends InventoryTransaction {
             }
         }
 
-        if (!ev.getNewItem().equals(this.outputItem, true, true)) {
+        if (!event.getNewItem().equals(this.outputItem, true, true)) {
             // Plugin changed item, so the previous slot change is going to be invalid
             // Send the replaced item to the enchant inventory manually
-            inv.setItemByPlayer(source, 0, ev.getNewItem(), true);
+            inv.setItemByPlayer(source, 0, event.getNewItem(), true);
         }
 
         if (!source.isCreative()) {
-            source.setExperience(source.getExperience(), source.getExperienceLevel() - ev.getXpCost());
+            source.setExperience(source.getExperience(), source.getExperienceLevel() - event.getXpCost());
         }
         return true;
     }

--- a/src/main/java/cn/nukkit/inventory/transaction/GrindstoneTransaction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/GrindstoneTransaction.java
@@ -103,7 +103,7 @@ public class GrindstoneTransaction extends InventoryTransaction {
         Item first = firstItem != null ? firstItem : air;
         Item second = secondItem != null ? secondItem : air;
         GrindstoneEvent event = new GrindstoneEvent(inventory, first, outputItem, second, exp, source);
-        this.source.getServer().getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) {
             this.source.removeAllWindows(false);
             this.sendInventories();

--- a/src/main/java/cn/nukkit/inventory/transaction/InventoryTransaction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/InventoryTransaction.java
@@ -190,8 +190,8 @@ public class InventoryTransaction {
     }
 
     protected boolean callExecuteEvent() {
-        InventoryTransactionEvent ev = new InventoryTransactionEvent(this);
-        this.source.getServer().getPluginManager().callEvent(ev);
+        InventoryTransactionEvent event = new InventoryTransactionEvent(this);
+        event.call();
 
         SlotChangeAction from = null;
         SlotChangeAction to = null;
@@ -219,16 +219,16 @@ public class InventoryTransaction {
                 from = to;
             }
 
-            InventoryClickEvent ev2 = new InventoryClickEvent(
+            InventoryClickEvent event1 = new InventoryClickEvent(
                     who, from.getInventory(), from.getSlot(), from.getSourceItem(), from.getTargetItem());
-            this.source.getServer().getPluginManager().callEvent(ev2);
+            event1.call();
 
-            if (ev2.isCancelled()) {
+            if (event1.isCancelled()) {
                 return false;
             }
         }
 
-        return !ev.isCancelled();
+        return !event.isCancelled();
     }
 
     @PowerNukkitDifference(since = "1.4.0.0-PN", info = "Always returns false if the execution is not possible")

--- a/src/main/java/cn/nukkit/inventory/transaction/RepairItemTransaction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/RepairItemTransaction.java
@@ -71,7 +71,7 @@ public class RepairItemTransaction extends InventoryTransaction {
 
         RepairItemEvent event = new RepairItemEvent(
                 inventory, this.inputItem, this.outputItem, this.materialItem, this.cost, this.source);
-        this.source.getServer().getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) {
             this.source.removeAllWindows(false);
             this.sendInventories();
@@ -95,18 +95,18 @@ public class RepairItemTransaction extends InventoryTransaction {
                             ? oldDamage + 1
                             : oldDamage;
 
-            AnvilDamageEvent ev = new AnvilDamageEvent(block, oldDamage, newDamage, DamageCause.USE, this.source);
-            ev.setCancelled(oldDamage == newDamage);
-            this.source.getServer().getPluginManager().callEvent(ev);
-            if (!ev.isCancelled()) {
-                BlockState newState = ev.getNewBlockState();
+            AnvilDamageEvent event1 = new AnvilDamageEvent(block, oldDamage, newDamage, DamageCause.USE, this.source);
+            if (oldDamage == newDamage) event1.cancel();
+            event1.call();
+            if (!event1.isCancelled()) {
+                BlockState newState = event1.getNewBlockState();
                 if (newState.getBlockId() == BlockID.AIR
                         || newState.getBlockId() == BlockID.ANVIL
                                 && newState.getPropertyValue(BlockAnvil.DAMAGE).equals(AnvilDamage.BROKEN)) {
                     this.source.level.setBlock(block, Block.get(Block.AIR), true);
                     this.source.level.addLevelEvent(block, LevelEventPacket.EVENT_SOUND_ANVIL_BREAK);
                 } else {
-                    if (!newState.equals(ev.getOldBlockState())) {
+                    if (!newState.equals(event1.getOldBlockState())) {
                         Block newBlock = newState.getBlockRepairing(block);
                         this.source.level.setBlock(block, newBlock, true);
                     }

--- a/src/main/java/cn/nukkit/inventory/transaction/SmithingTransaction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/SmithingTransaction.java
@@ -110,7 +110,7 @@ public class SmithingTransaction extends InventoryTransaction {
         Item equipment = equipmentItem != null ? equipmentItem : air;
         Item ingredient = ingredientItem != null ? ingredientItem : air;
         SmithingTableEvent event = new SmithingTableEvent(inventory, equipment, outputItem, ingredient, source);
-        this.source.getServer().getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) {
             this.source.removeAllWindows(false);
             this.sendInventories();

--- a/src/main/java/cn/nukkit/inventory/transaction/action/DamageAnvilAction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/action/DamageAnvilAction.java
@@ -46,11 +46,11 @@ public class DamageAnvilAction extends InventoryAction {
         } else {
             newState.setDamage(newState.getDamage() & (Block.DATA_MASK ^ 0b1100) | (damage << 2));
         }
-        AnvilDamageEvent ev =
+        AnvilDamageEvent event =
                 new AnvilDamageEvent(levelBlock, newState, source, transaction, AnvilDamageEvent.DamageCause.USE);
-        ev.setCancelled(!shouldDamage);
-        source.getServer().getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        if (!shouldDamage) event.cancel();
+        event.call();
+        if (event.isCancelled()) {
             levelBlock.getLevel().addSound(levelBlock, Sound.RANDOM_ANVIL_USE);
             return true;
         } else {

--- a/src/main/java/cn/nukkit/inventory/transaction/action/DropItemAction.java
+++ b/src/main/java/cn/nukkit/inventory/transaction/action/DropItemAction.java
@@ -26,14 +26,14 @@ public class DropItemAction extends InventoryAction {
 
     @Override
     public boolean onPreExecute(Player source) {
-        PlayerDropItemEvent ev;
-        source.getServer().getPluginManager().callEvent(ev = new PlayerDropItemEvent(source, this.targetItem));
+        PlayerDropItemEvent event = new PlayerDropItemEvent(source, this.targetItem);
+        event.call();
 
-        if (ev.isCancelled()) {
+        if (event.isCancelled()) {
             source.stopAction();
         }
 
-        return !ev.isCancelled();
+        return !event.isCancelled();
     }
 
     /**

--- a/src/main/java/cn/nukkit/item/ItemBow.java
+++ b/src/main/java/cn/nukkit/item/ItemBow.java
@@ -1,6 +1,5 @@
 package cn.nukkit.item;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitDifference;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.entity.projectile.EntityArrow;
@@ -108,10 +107,10 @@ public class ItemBow extends ItemTool {
         EntityShootBowEvent entityShootBowEvent = new EntityShootBowEvent(player, this, arrow, f);
 
         if (f < 0.1 || ticksUsed < 3) {
-            entityShootBowEvent.setCancelled();
+            entityShootBowEvent.cancel();
         }
 
-        Server.getInstance().getPluginManager().callEvent(entityShootBowEvent);
+        entityShootBowEvent.call();
         if (entityShootBowEvent.isCancelled()) {
             entityShootBowEvent.getProjectile().kill();
             player.getInventory().sendContents(player);
@@ -153,10 +152,10 @@ public class ItemBow extends ItemTool {
                 }
             }
             if (entityShootBowEvent.getProjectile() != null) {
-                ProjectileLaunchEvent projectev =
+                ProjectileLaunchEvent projectileLaunchEvent =
                         new ProjectileLaunchEvent(entityShootBowEvent.getProjectile(), player);
-                Server.getInstance().getPluginManager().callEvent(projectev);
-                if (projectev.isCancelled()) {
+                projectileLaunchEvent.call();
+                if (projectileLaunchEvent.isCancelled()) {
                     entityShootBowEvent.getProjectile().kill();
                 } else {
                     entityShootBowEvent.getProjectile().spawnToAll();

--- a/src/main/java/cn/nukkit/item/ItemCrossbow.java
+++ b/src/main/java/cn/nukkit/item/ItemCrossbow.java
@@ -186,7 +186,7 @@ public class ItemCrossbow extends ItemTool {
             } else {
                 EntityArrow entity = new EntityArrow(player.chunk, nbt, player, false);
                 EntityShootCrossbowEvent entityShootBowEvent = new EntityShootCrossbowEvent(player, this, entity);
-                Server.getInstance().getPluginManager().callEvent(entityShootBowEvent);
+                entityShootBowEvent.call();
                 if (entityShootBowEvent.isCancelled()) {
                     entityShootBowEvent.getProjectile(0).close();
                     player.getInventory().sendContents(player);
@@ -199,9 +199,9 @@ public class ItemCrossbow extends ItemTool {
                                     .multiply(3.5D));
                     if (entityShootBowEvent.getProjectile(0) != null) {
                         EntityProjectile proj = entityShootBowEvent.getProjectile(0);
-                        ProjectileLaunchEvent projectile = new ProjectileLaunchEvent(proj, player);
-                        Server.getInstance().getPluginManager().callEvent(projectile);
-                        if (projectile.isCancelled()) {
+                        ProjectileLaunchEvent projectileLaunchEvent = new ProjectileLaunchEvent(proj, player);
+                        projectileLaunchEvent.call();
+                        if (projectileLaunchEvent.isCancelled()) {
                             proj.close();
                         } else {
                             proj.spawnToAll();

--- a/src/main/java/cn/nukkit/item/ItemEdible.java
+++ b/src/main/java/cn/nukkit/item/ItemEdible.java
@@ -55,8 +55,8 @@ public abstract class ItemEdible extends Item {
         }
 
         PlayerItemConsumeEvent consumeEvent = new PlayerItemConsumeEvent(player, this);
+        consumeEvent.call();
 
-        player.getServer().getPluginManager().callEvent(consumeEvent);
         if (consumeEvent.isCancelled()) {
             player.getInventory().sendContents(player);
             return false;

--- a/src/main/java/cn/nukkit/item/ItemFireCharge.java
+++ b/src/main/java/cn/nukkit/item/ItemFireCharge.java
@@ -53,11 +53,11 @@ public class ItemFireCharge extends Item {
             fire.level = level;
 
             if (fire.isBlockTopFacingSurfaceSolid(fire.down()) || fire.canNeighborBurn()) {
-                BlockIgniteEvent e =
+                BlockIgniteEvent event =
                         new BlockIgniteEvent(block, null, player, BlockIgniteEvent.BlockIgniteCause.FLINT_AND_STEEL);
-                block.getLevel().getServer().getPluginManager().callEvent(e);
+                event.call();
 
-                if (!e.isCancelled()) {
+                if (!event.isCancelled()) {
                     level.setBlock(fire, fire, true);
                     level.addLevelEvent(block, LevelEventPacket.EVENT_SOUND_GHAST_SHOOT, 78642);
                     level.scheduleUpdate(

--- a/src/main/java/cn/nukkit/item/ItemFlintSteel.java
+++ b/src/main/java/cn/nukkit/item/ItemFlintSteel.java
@@ -60,11 +60,11 @@ public class ItemFlintSteel extends ItemTool {
             fire.level = level;
 
             if (fire.isBlockTopFacingSurfaceSolid(fire.down()) || fire.canNeighborBurn()) {
-                BlockIgniteEvent e =
+                BlockIgniteEvent event =
                         new BlockIgniteEvent(block, null, player, BlockIgniteEvent.BlockIgniteCause.FLINT_AND_STEEL);
-                block.getLevel().getServer().getPluginManager().callEvent(e);
+                event.call();
 
-                if (!e.isCancelled()) {
+                if (!event.isCancelled()) {
                     level.setBlock(fire, fire, true);
                     level.scheduleUpdate(
                             fire, fire.tickRate() + ThreadLocalRandom.current().nextInt(10));

--- a/src/main/java/cn/nukkit/item/ItemPotion.java
+++ b/src/main/java/cn/nukkit/item/ItemPotion.java
@@ -134,7 +134,7 @@ public class ItemPotion extends Item {
     @Override
     public boolean onUse(Player player, int ticksUsed) {
         PlayerItemConsumeEvent consumeEvent = new PlayerItemConsumeEvent(player, this);
-        player.getServer().getPluginManager().callEvent(consumeEvent);
+        consumeEvent.call();
         if (consumeEvent.isCancelled()) {
             return false;
         }

--- a/src/main/java/cn/nukkit/item/ItemSpawnEgg.java
+++ b/src/main/java/cn/nukkit/item/ItemSpawnEgg.java
@@ -100,10 +100,10 @@ public class ItemSpawnEgg extends Item {
         }
 
         int networkId = getEntityNetworkId();
-        CreatureSpawnEvent ev = new CreatureSpawnEvent(networkId, block, nbt, SpawnReason.SPAWN_EGG);
-        level.getServer().getPluginManager().callEvent(ev);
+        CreatureSpawnEvent event = new CreatureSpawnEvent(networkId, block, nbt, SpawnReason.SPAWN_EGG);
+        event.call();
 
-        if (ev.isCancelled()) {
+        if (event.isCancelled()) {
             return false;
         }
 

--- a/src/main/java/cn/nukkit/item/ItemTrident.java
+++ b/src/main/java/cn/nukkit/item/ItemTrident.java
@@ -1,6 +1,5 @@
 package cn.nukkit.item;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitDifference;
 import cn.nukkit.entity.projectile.EntityProjectile;
 import cn.nukkit.entity.projectile.EntityThrownTrident;
@@ -87,10 +86,10 @@ public class ItemTrident extends ItemTool {
         EntityShootBowEvent entityShootBowEvent = new EntityShootBowEvent(player, this, trident, f);
 
         if (f < 0.1 || ticksUsed < 5) {
-            entityShootBowEvent.setCancelled();
+            entityShootBowEvent.cancel();
         }
 
-        Server.getInstance().getPluginManager().callEvent(entityShootBowEvent);
+        entityShootBowEvent.call();
         if (entityShootBowEvent.isCancelled()) {
             entityShootBowEvent.getProjectile().close();
         } else {
@@ -98,9 +97,10 @@ public class ItemTrident extends ItemTool {
                     .getProjectile()
                     .setMotion(
                             entityShootBowEvent.getProjectile().getMotion().multiply(entityShootBowEvent.getForce()));
-            ProjectileLaunchEvent ev = new ProjectileLaunchEvent(entityShootBowEvent.getProjectile(), player);
-            Server.getInstance().getPluginManager().callEvent(ev);
-            if (ev.isCancelled()) {
+            ProjectileLaunchEvent projectileLaunchEvent =
+                    new ProjectileLaunchEvent(entityShootBowEvent.getProjectile(), player);
+            projectileLaunchEvent.call();
+            if (projectileLaunchEvent.isCancelled()) {
                 entityShootBowEvent.getProjectile().close();
             } else {
                 entityShootBowEvent.getProjectile().spawnToAll();

--- a/src/main/java/cn/nukkit/item/ProjectileItem.java
+++ b/src/main/java/cn/nukkit/item/ProjectileItem.java
@@ -57,10 +57,10 @@ public abstract class ProjectileItem extends Item {
             projectile.setMotion(projectile.getMotion().multiply(this.getThrowForce()));
 
             if (projectile instanceof EntityProjectile) {
-                ProjectileLaunchEvent ev = new ProjectileLaunchEvent((EntityProjectile) projectile, player);
+                ProjectileLaunchEvent event = new ProjectileLaunchEvent((EntityProjectile) projectile, player);
+                event.call();
 
-                player.getServer().getPluginManager().callEvent(ev);
-                if (ev.isCancelled()) {
+                if (event.isCancelled()) {
                     projectile.kill();
                 } else {
                     if (!player.isCreative()) {

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentFireAspect.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentFireAspect.java
@@ -1,6 +1,5 @@
 package cn.nukkit.item.enchantment;
 
-import cn.nukkit.Server;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.entity.EntityCombustByEntityEvent;
 import cn.nukkit.player.Player;
@@ -33,11 +32,11 @@ public class EnchantmentFireAspect extends Enchantment {
         if ((!(entity instanceof Player) || !((Player) entity).isCreative())) {
             int duration = Math.max(entity.fireTicks / 20, getLevel() << 2);
 
-            EntityCombustByEntityEvent ev = new EntityCombustByEntityEvent(attacker, entity, duration);
-            Server.getInstance().getPluginManager().callEvent(ev);
+            EntityCombustByEntityEvent event = new EntityCombustByEntityEvent(attacker, entity, duration);
+            event.call();
 
-            if (!ev.isCancelled()) {
-                entity.setOnFire(ev.getDuration());
+            if (!event.isCancelled()) {
+                entity.setOnFire(event.getDuration());
             }
         }
     }

--- a/src/main/java/cn/nukkit/item/food/Food.java
+++ b/src/main/java/cn/nukkit/item/food/Food.java
@@ -214,7 +214,7 @@ public abstract class Food {
 
     public final boolean eatenBy(Player player) {
         PlayerEatFoodEvent event = new PlayerEatFoodEvent(player, this);
-        player.getServer().getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) return false;
         return event.getFood().onEatenBy(player);
     }

--- a/src/main/java/cn/nukkit/level/Explosion.java
+++ b/src/main/java/cn/nukkit/level/Explosion.java
@@ -235,32 +235,33 @@ public class Explosion {
 
         if (this.what instanceof Entity) {
             List<Block> affectedBlocksList = new ArrayList<>(this.affectedBlocks);
-            EntityExplodeEvent ev = new EntityExplodeEvent((Entity) this.what, this.source, affectedBlocksList, yield);
-            ev.setIgnitions(fireIgnitions == null ? new LinkedHashSet<>(0) : fireIgnitions);
-            this.level.getServer().getPluginManager().callEvent(ev);
-            if (ev.isCancelled()) {
+            EntityExplodeEvent event =
+                    new EntityExplodeEvent((Entity) this.what, this.source, affectedBlocksList, yield);
+            event.setIgnitions(fireIgnitions == null ? new LinkedHashSet<>(0) : fireIgnitions);
+            event.call();
+            if (event.isCancelled()) {
                 return false;
             } else {
-                yield = ev.getYield();
+                yield = event.getYield();
                 affectedBlocks.clear();
-                affectedBlocks.addAll(ev.getBlockList());
-                fireIgnitions = ev.getIgnitions();
+                affectedBlocks.addAll(event.getBlockList());
+                fireIgnitions = event.getIgnitions();
             }
         } else if (this.what instanceof Block) {
-            BlockExplodeEvent ev = new BlockExplodeEvent(
+            BlockExplodeEvent event = new BlockExplodeEvent(
                     (Block) this.what,
                     this.source,
                     this.affectedBlocks,
                     fireIgnitions == null ? new LinkedHashSet<>(0) : fireIgnitions,
                     yield,
                     this.fireChance);
-            this.level.getServer().getPluginManager().callEvent(ev);
-            if (ev.isCancelled()) {
+            event.call();
+            if (event.isCancelled()) {
                 return false;
             } else {
-                yield = ev.getYield();
-                affectedBlocks = ev.getAffectedBlocks();
-                fireIgnitions = ev.getIgnitions();
+                yield = event.getYield();
+                affectedBlocks = event.getAffectedBlocks();
+                fireIgnitions = event.getIgnitions();
             }
         }
 
@@ -349,17 +350,17 @@ public class Explosion {
                 Vector3 sideBlock = pos.getSide(side);
                 long index = Hash.hashBlock((int) sideBlock.x, (int) sideBlock.y, (int) sideBlock.z);
                 if (!this.affectedBlocks.contains(sideBlock) && !updateBlocks.contains(index)) {
-                    BlockUpdateEvent ev = new BlockUpdateEvent(this.level.getBlock(sideBlock));
-                    this.level.getServer().getPluginManager().callEvent(ev);
-                    if (!ev.isCancelled()) {
-                        ev.getBlock().onUpdate(Level.BLOCK_UPDATE_NORMAL);
+                    BlockUpdateEvent event = new BlockUpdateEvent(this.level.getBlock(sideBlock));
+                    event.call();
+                    if (!event.isCancelled()) {
+                        event.getBlock().onUpdate(Level.BLOCK_UPDATE_NORMAL);
                     }
                     Block layer1 = this.level.getBlock(sideBlock, 1);
                     if (layer1.getId() != BlockID.AIR) {
-                        ev = new BlockUpdateEvent(layer1);
-                        this.level.getServer().getPluginManager().callEvent(ev);
-                        if (!ev.isCancelled()) {
-                            ev.getBlock().onUpdate(Level.BLOCK_UPDATE_NORMAL);
+                        event = new BlockUpdateEvent(layer1);
+                        event.call();
+                        if (!event.isCancelled()) {
+                            event.getBlock().onUpdate(Level.BLOCK_UPDATE_NORMAL);
                         }
                     }
                     updateBlocks.add(index);

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -1060,15 +1060,15 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public boolean unload(boolean force) {
-        LevelUnloadEvent ev = new LevelUnloadEvent(this);
+        LevelUnloadEvent event = new LevelUnloadEvent(this);
 
         if (this == this.server.getDefaultLevel() && !force) {
-            ev.setCancelled();
+            event.cancel();
         }
 
-        this.server.getPluginManager().callEvent(ev);
+        event.call();
 
-        if (!force && ev.isCancelled()) {
+        if (!force && event.isCancelled()) {
             return false;
         }
 
@@ -1292,7 +1292,7 @@ public class Level implements ChunkManager, Metadatable {
                 QueuedUpdate queuedUpdate = this.normalUpdateQueue.poll();
                 Block block = getBlock(queuedUpdate.block, queuedUpdate.block.layer);
                 BlockUpdateEvent event = new BlockUpdateEvent(block);
-                this.server.getPluginManager().callEvent(event);
+                event.call();
 
                 if (!event.isCancelled()) {
                     block.onUpdate(BLOCK_UPDATE_NORMAL);
@@ -1559,9 +1559,9 @@ public class Level implements ChunkManager, Metadatable {
                             .add(new FloatTag("", 0)));
 
             EntityLightning bolt = new EntityLightning(chunk, nbt);
-            LightningStrikeEvent ev = new LightningStrikeEvent(this, bolt);
-            getServer().getPluginManager().callEvent(ev);
-            if (!ev.isCancelled()) {
+            LightningStrikeEvent event = new LightningStrikeEvent(this, bolt);
+            event.call();
+            if (!event.isCancelled()) {
                 bolt.spawnToAll();
             } else {
                 bolt.setEffect(false);
@@ -1842,7 +1842,8 @@ public class Level implements ChunkManager, Metadatable {
             return false;
         }
 
-        this.server.getPluginManager().callEvent(new LevelSaveEvent(this));
+        LevelSaveEvent event = new LevelSaveEvent(this);
+        event.call();
 
         LevelProvider levelProvider = this.requireProvider();
         levelProvider.setTime((int) this.time);
@@ -2845,14 +2846,14 @@ public class Level implements ChunkManager, Metadatable {
             /*if (blockPrevious.isTransparent() != block.isTransparent() || blockPrevious.getLightLevel() != block.getLightLevel()) {
                 addLightUpdate(x, y, z);
             }*/
-            BlockUpdateEvent ev = new BlockUpdateEvent(block);
-            this.server.getPluginManager().callEvent(ev);
-            if (!ev.isCancelled()) {
+            BlockUpdateEvent event = new BlockUpdateEvent(block);
+            event.call();
+            if (!event.isCancelled()) {
                 for (Entity entity :
                         this.getNearbyEntities(new SimpleAxisAlignedBB(x - 1, y - 1, z - 1, x + 1, y + 1, z + 1))) {
                     entity.scheduleUpdate();
                 }
-                block = ev.getBlock();
+                block = event.getBlock();
                 block.onUpdate(BLOCK_UPDATE_NORMAL);
                 block.getLevelBlockAtLayer(layer == 0 ? 1 : 0).onUpdate(BLOCK_UPDATE_NORMAL);
                 this.updateAround(x, y, z);
@@ -3116,29 +3117,29 @@ public class Level implements ChunkManager, Metadatable {
                 // thisBreak-lastBreak < breakTime-1000ms = the player is hacker (fastBreak)
                 boolean fastBreak = Long.sum(player.lastBreak, (long) breakTime * 1000)
                         > Long.sum(System.currentTimeMillis(), 1000);
-                BlockBreakEvent ev =
+                BlockBreakEvent event =
                         new BlockBreakEvent(player, target, face, item, eventDrops, player.isCreative(), fastBreak);
                 if (player.isSurvival() && !target.isBreakable(item)) {
-                    ev.setCancelled();
+                    event.cancel();
                 } else if (!player.isOp() && isInSpawnRadius(target)) {
-                    ev.setCancelled();
-                } else if (!ev.getInstaBreak() && ev.isFastBreak()) {
-                    ev.setCancelled();
+                    event.cancel();
+                } else if (!event.getInstaBreak() && event.isFastBreak()) {
+                    event.cancel();
                 }
 
-                this.server.getPluginManager().callEvent(ev);
-                if (ev.isCancelled()) {
+                event.call();
+                if (event.isCancelled()) {
                     return null;
                 }
 
-                if (!ev.getInstaBreak() && ev.isFastBreak()) {
+                if (!event.getInstaBreak() && event.isFastBreak()) {
                     return null;
                 }
 
                 player.lastBreak = System.currentTimeMillis();
 
-                drops = ev.getDrops();
-                dropExp = ev.getDropExp();
+                drops = event.getDrops();
+                dropExp = event.getDropExp();
             } else {
                 drops = eventDrops;
             }
@@ -3305,7 +3306,7 @@ public class Level implements ChunkManager, Metadatable {
         }
         int touchStatus = 0;
         if (player != null) {
-            PlayerInteractEvent ev = new PlayerInteractEvent(
+            PlayerInteractEvent event = new PlayerInteractEvent(
                     player,
                     item,
                     target,
@@ -3313,16 +3314,16 @@ public class Level implements ChunkManager, Metadatable {
                     target.getId() == 0 ? Action.RIGHT_CLICK_AIR : Action.RIGHT_CLICK_BLOCK);
 
             if (player.getGamemode() > 2) {
-                ev.setCancelled();
+                event.cancel();
             }
             // handle spawn protect
             if (!player.isOp() && isInSpawnRadius(target)) {
-                ev.setCancelled();
+                event.cancel();
             }
-            this.server.getPluginManager().callEvent(ev);
-            if (!ev.isCancelled()) {
-                target.onTouch(player, ev.getAction());
-                if (ev.getAction() == Action.RIGHT_CLICK_BLOCK) {
+            event.call();
+            if (!event.isCancelled()) {
+                target.onTouch(player, event.getAction());
+                if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
                     target.onPlayerRightClick(player, item, face, new Vector3(fx, fy, fz));
                 }
                 if ((!player.isSneaking()
@@ -3444,14 +3445,14 @@ public class Level implements ChunkManager, Metadatable {
                     }
                 }
                 if (!canPlace) {
-                    event.setCancelled();
+                    event.cancel();
                 }
             }
             if (!player.isOp() && isInSpawnRadius(target)) {
-                event.setCancelled();
+                event.cancel();
             }
 
-            this.server.getPluginManager().callEvent(event);
+            event.call();
             if (event.isCancelled()) {
                 return null;
             }
@@ -3942,7 +3943,8 @@ public class Level implements ChunkManager, Metadatable {
                     && (oldChunk == null || !isPopulated)
                     && chunk.isPopulated()
                     && chunk.getProvider() != null) {
-                this.server.getPluginManager().callEvent(new ChunkPopulateEvent(chunk));
+                ChunkPopulateEvent event = new ChunkPopulateEvent(chunk);
+                event.call();
 
                 for (ChunkLoader loader : this.getChunkLoaders(x, z)) {
                     loader.onChunkPopulated(chunk);
@@ -4170,7 +4172,8 @@ public class Level implements ChunkManager, Metadatable {
     public void setSpawnLocation(Vector3 pos) {
         Position previousSpawn = this.getSpawnLocation();
         this.requireProvider().setSpawn(pos);
-        this.server.getPluginManager().callEvent(new SpawnChangeEvent(this, previousSpawn));
+        SpawnChangeEvent event = new SpawnChangeEvent(this, previousSpawn);
+        event.call();
         SetSpawnPositionPacket pk = new SetSpawnPositionPacket();
         pk.spawnType = SetSpawnPositionPacket.TYPE_WORLD_SPAWN;
         pk.x = pos.getFloorX();
@@ -4390,7 +4393,7 @@ public class Level implements ChunkManager, Metadatable {
         }
 
         if (chunk.getProvider() != null) {
-            this.server.getPluginManager().callEvent(new ChunkLoadEvent(chunk, !chunk.isGenerated()));
+            new ChunkLoadEvent(chunk, !chunk.isGenerated()).call();
         } else {
             this.unloadChunk(x, z, false);
             return chunk;
@@ -4463,9 +4466,9 @@ public class Level implements ChunkManager, Metadatable {
         BaseFullChunk chunk = this.getChunk(x, z);
 
         if (chunk != null && chunk.getProvider() != null) {
-            ChunkUnloadEvent ev = new ChunkUnloadEvent(chunk);
-            this.server.getPluginManager().callEvent(ev);
-            if (ev.isCancelled()) {
+            ChunkUnloadEvent event = new ChunkUnloadEvent(chunk);
+            event.call();
+            if (event.isCancelled()) {
                 return false;
             }
         }
@@ -4998,10 +5001,10 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public boolean setRaining(boolean raining) {
-        WeatherChangeEvent ev = new WeatherChangeEvent(this, raining);
-        this.getServer().getPluginManager().callEvent(ev);
+        WeatherChangeEvent event = new WeatherChangeEvent(this, raining);
+        event.call();
 
-        if (ev.isCancelled()) {
+        if (event.isCancelled()) {
             return false;
         }
 
@@ -5038,10 +5041,10 @@ public class Level implements ChunkManager, Metadatable {
     }
 
     public boolean setThundering(boolean thundering) {
-        ThunderChangeEvent ev = new ThunderChangeEvent(this, thundering);
-        this.getServer().getPluginManager().callEvent(ev);
+        ThunderChangeEvent event = new ThunderChangeEvent(this, thundering);
+        event.call();
 
-        if (ev.isCancelled()) {
+        if (event.isCancelled()) {
             return false;
         }
 

--- a/src/main/java/cn/nukkit/level/generator/Flat.java
+++ b/src/main/java/cn/nukkit/level/generator/Flat.java
@@ -1,6 +1,5 @@
 package cn.nukkit.level.generator;
 
-import cn.nukkit.Server;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockID;
 import cn.nukkit.event.level.ChunkPrePopulateEvent;
@@ -183,8 +182,8 @@ public class Flat extends Generator {
     public void populateChunk(int chunkX, int chunkZ) {
         BaseFullChunk chunk = level.getChunk(chunkX, chunkZ);
         this.random.setSeed(0xdeadbeef ^ ((long) chunkX << 8) ^ chunkZ ^ this.level.getSeed());
-        var event = new ChunkPrePopulateEvent(chunk, this.populators, List.of());
-        Server.getInstance().getPluginManager().callEvent(event);
+        ChunkPrePopulateEvent event = new ChunkPrePopulateEvent(chunk, this.populators, List.of());
+        event.call();
         for (Populator populator : event.getTerrainPopulators()) {
             populator.populate(this.level, chunkX, chunkZ, this.random, chunk);
         }

--- a/src/main/java/cn/nukkit/level/generator/Nether.java
+++ b/src/main/java/cn/nukkit/level/generator/Nether.java
@@ -1,6 +1,5 @@
 package cn.nukkit.level.generator;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockID;
@@ -173,8 +172,8 @@ public class Nether extends Generator {
         this.nukkitRandom.setSeed(0xdeadbeef ^ ((long) chunkX << 8) ^ chunkZ ^ this.level.getSeed());
         @SuppressWarnings("deprecation")
         Biome biome = EnumBiome.getBiome(chunk.getBiomeId(7, 7));
-        var event = new ChunkPrePopulateEvent(chunk, this.populators, biome.getPopulators());
-        Server.getInstance().getPluginManager().callEvent(event);
+        ChunkPrePopulateEvent event = new ChunkPrePopulateEvent(chunk, this.populators, biome.getPopulators());
+        event.call();
         for (Populator populator : event.getTerrainPopulators()) {
             populator.populate(this.level, chunkX, chunkZ, this.nukkitRandom, chunk);
         }

--- a/src/main/java/cn/nukkit/level/generator/Normal.java
+++ b/src/main/java/cn/nukkit/level/generator/Normal.java
@@ -1,6 +1,5 @@
 package cn.nukkit.level.generator;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockID;
@@ -413,8 +412,8 @@ public class Normal extends Generator {
         this.nukkitRandom.setSeed(0xdeadbeef ^ ((long) chunkX << 8) ^ chunkZ ^ this.level.getSeed());
         @SuppressWarnings("deprecation")
         Biome biome = EnumBiome.getBiome(chunk.getBiomeId(7, 7));
-        var event = new ChunkPrePopulateEvent(chunk, this.populators, biome.getPopulators());
-        Server.getInstance().getPluginManager().callEvent(event);
+        ChunkPrePopulateEvent event = new ChunkPrePopulateEvent(chunk, this.populators, biome.getPopulators());
+        event.call();
         for (Populator populator : event.getTerrainPopulators()) {
             populator.populate(this.level, chunkX, chunkZ, this.nukkitRandom, chunk);
         }

--- a/src/main/java/cn/nukkit/level/generator/TerraGeneratorWrapper.java
+++ b/src/main/java/cn/nukkit/level/generator/TerraGeneratorWrapper.java
@@ -1,8 +1,8 @@
 package cn.nukkit.level.generator;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
+import cn.nukkit.event.HandlerListManager;
 import cn.nukkit.event.level.ChunkPrePopulateEvent;
 import cn.nukkit.level.ChunkManager;
 import cn.nukkit.level.DimensionData;
@@ -59,11 +59,11 @@ public class TerraGeneratorWrapper extends Generator {
 
     @Override
     public void populateChunk(int chunkX, int chunkZ) {
-        if (!ChunkPrePopulateEvent.getHandlers().isEmpty()) {
+        if (!HandlerListManager.global().getListFor(ChunkPrePopulateEvent.class).isEmpty()) {
             var nukkitRandom = new NukkitRandom(0xdeadbeef ^ ((long) chunkX << 8) ^ chunkZ ^ this.level.getSeed());
             var chunk = level.getChunk(chunkX, chunkZ);
             var event = new ChunkPrePopulateEvent(chunk, List.of(), List.of());
-            Server.getInstance().getPluginManager().callEvent(event);
+            event.call();
             this.terra.populateChunk(chunkX, chunkZ, getChunkManager());
             for (var populator : event.getTerrainPopulators())
                 populator.populate(level, chunkX, chunkX, nukkitRandom, chunk);

--- a/src/main/java/cn/nukkit/level/generator/TheEnd.java
+++ b/src/main/java/cn/nukkit/level/generator/TheEnd.java
@@ -1,6 +1,5 @@
 package cn.nukkit.level.generator;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockstate.BlockState;
 import cn.nukkit.event.level.ChunkPrePopulateEvent;
@@ -281,8 +280,8 @@ public class TheEnd extends Generator {
         this.nukkitRandom.setSeed(0xdeadbeef ^ ((long) chunkX << 8) ^ chunkZ ^ this.level.getSeed());
         @SuppressWarnings("deprecation")
         Biome biome = EnumBiome.getBiome(chunk.getBiomeId(7, 7));
-        var event = new ChunkPrePopulateEvent(chunk, this.populators, biome.getPopulators());
-        Server.getInstance().getPluginManager().callEvent(event);
+        ChunkPrePopulateEvent event = new ChunkPrePopulateEvent(chunk, this.populators, biome.getPopulators());
+        event.call();
         for (Populator populator : event.getTerrainPopulators()) {
             populator.populate(this.level, chunkX, chunkZ, this.nukkitRandom, chunk);
         }

--- a/src/main/java/cn/nukkit/level/vibration/SimpleVibrationManager.java
+++ b/src/main/java/cn/nukkit/level/vibration/SimpleVibrationManager.java
@@ -31,7 +31,7 @@ public class SimpleVibrationManager implements VibrationManager {
     @Override
     public void callVibrationEvent(VibrationEvent event) {
         VibrationOccurEvent vibrationOccurPluginEvent = new VibrationOccurEvent(event);
-        this.level.getServer().getPluginManager().callEvent(vibrationOccurPluginEvent);
+        vibrationOccurPluginEvent.call();
         if (vibrationOccurPluginEvent.isCancelled()) {
             return;
         }
@@ -48,7 +48,7 @@ public class SimpleVibrationManager implements VibrationManager {
                                 () -> {
                                     VibrationArriveEvent vibrationArrivePluginEvent =
                                             new VibrationArriveEvent(event, listener);
-                                    this.level.getServer().getPluginManager().callEvent(vibrationArrivePluginEvent);
+                                    vibrationArrivePluginEvent.call();
                                     if (vibrationArrivePluginEvent.isCancelled()) {
                                         return;
                                     }

--- a/src/main/java/cn/nukkit/network/RakNetInterface.java
+++ b/src/main/java/cn/nukkit/network/RakNetInterface.java
@@ -69,7 +69,7 @@ public class RakNetInterface implements RakNetServerListener, AdvancedSourceInte
 
             try {
                 PlayerCreationEvent event = new PlayerCreationEvent(this, Player.class, Player.class, null, address);
-                this.server.getPluginManager().callEvent(event);
+                event.call();
 
                 this.sessions.put(event.getSocketAddress(), session);
 

--- a/src/main/java/cn/nukkit/network/process/processor/AnimateProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/AnimateProcessor.java
@@ -29,7 +29,7 @@ public class AnimateProcessor extends DataPacketProcessor<AnimatePacket> {
         }
 
         PlayerAnimationEvent animationEvent = new PlayerAnimationEvent(player, pk);
-        player.getServer().getPluginManager().callEvent(animationEvent);
+        animationEvent.call();
         if (animationEvent.isCancelled()) {
             return;
         }

--- a/src/main/java/cn/nukkit/network/process/processor/BlockPickRequestProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/BlockPickRequestProcessor.java
@@ -40,10 +40,10 @@ public class BlockPickRequestProcessor extends DataPacketProcessor<BlockPickRequ
         PlayerBlockPickEvent pickEvent = new PlayerBlockPickEvent(player, block, item);
         if (player.isSpectator()) {
             log.debug("Got block-pick request from {} when in spectator mode", player.getName());
-            pickEvent.setCancelled();
+            pickEvent.cancel();
         }
 
-        player.getServer().getPluginManager().callEvent(pickEvent);
+        pickEvent.call();
 
         if (!pickEvent.isCancelled()) {
             boolean itemExists = false;

--- a/src/main/java/cn/nukkit/network/process/processor/BookEditProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/BookEditProcessor.java
@@ -62,7 +62,7 @@ public class BookEditProcessor extends DataPacketProcessor<BookEditPacket> {
 
         if (success) {
             PlayerEditBookEvent editBookEvent = new PlayerEditBookEvent(player, oldBook, newBook, pk.action);
-            player.getServer().getPluginManager().callEvent(editBookEvent);
+            editBookEvent.call();
             if (!editBookEvent.isCancelled()) {
                 player.getInventory().setItem(pk.inventorySlot, editBookEvent.getNewBook());
             }

--- a/src/main/java/cn/nukkit/network/process/processor/CommandRequestProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/CommandRequestProcessor.java
@@ -18,7 +18,7 @@ public class CommandRequestProcessor extends DataPacketProcessor<CommandRequestP
         playerHandle.player.craftingType = Player.CRAFTING_SMALL;
         PlayerCommandPreprocessEvent playerCommandPreprocessEvent =
                 new PlayerCommandPreprocessEvent(playerHandle.player, pk.command);
-        playerHandle.player.getServer().getPluginManager().callEvent(playerCommandPreprocessEvent);
+        playerCommandPreprocessEvent.call();
         if (playerCommandPreprocessEvent.isCancelled()) {
             return;
         }

--- a/src/main/java/cn/nukkit/network/process/processor/ContainerCloseProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/ContainerCloseProcessor.java
@@ -18,10 +18,7 @@ public class ContainerCloseProcessor extends DataPacketProcessor<ContainerCloseP
         }
 
         if (playerHandle.getWindowIndex().containsKey(pk.windowId)) {
-            player.getServer()
-                    .getPluginManager()
-                    .callEvent(new InventoryCloseEvent(
-                            playerHandle.getWindowIndex().get(pk.windowId), player));
+            new InventoryCloseEvent(playerHandle.getWindowIndex().get(pk.windowId), player).call();
             if (pk.windowId == ContainerIds.INVENTORY) playerHandle.setInventoryOpen(false);
             playerHandle.setClosingWindowId(pk.windowId);
             playerHandle.removeWindow(playerHandle.getWindowIndex().get(pk.windowId), true);

--- a/src/main/java/cn/nukkit/network/process/processor/FilterTextProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/FilterTextProcessor.java
@@ -26,7 +26,7 @@ public class FilterTextProcessor extends DataPacketProcessor<FilterTextPacket> {
             if (anvilInventory != null) {
                 PlayerTypingAnvilInventoryEvent playerTypingAnvilInventoryEvent = new PlayerTypingAnvilInventoryEvent(
                         player, anvilInventory, anvilInventory.getNewItemName(), pk.getText());
-                player.getServer().getPluginManager().callEvent(playerTypingAnvilInventoryEvent);
+                playerTypingAnvilInventoryEvent.call();
                 anvilInventory.setNewItemName(playerTypingAnvilInventoryEvent.getTypedName());
             }
         }

--- a/src/main/java/cn/nukkit/network/process/processor/InteractProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/InteractProcessor.java
@@ -55,7 +55,7 @@ public class InteractProcessor extends DataPacketProcessor<InteractPacket> {
                 if (pk.target == 0) {
                     return;
                 }
-                player.getServer().getPluginManager().callEvent(new PlayerMouseOverEntityEvent(player, targetEntity));
+                new PlayerMouseOverEntityEvent(player, targetEntity).call();
             }
             case InteractPacket.ACTION_VEHICLE_EXIT -> {
                 if (!(targetEntity instanceof EntityRideable) || player.riding == null) {

--- a/src/main/java/cn/nukkit/network/process/processor/InventoryTransactionProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/InventoryTransactionProcessor.java
@@ -464,8 +464,8 @@ public class InventoryTransactionProcessor extends DataPacketProcessor<Inventory
             case InventoryTransactionPacket.USE_ITEM_ON_ENTITY_ACTION_INTERACT -> {
                 PlayerInteractEntityEvent playerInteractEntityEvent =
                         new PlayerInteractEntityEvent(player, target, item, useItemOnEntityData.clickPos);
-                if (player.isSpectator()) playerInteractEntityEvent.setCancelled();
-                player.getServer().getPluginManager().callEvent(playerInteractEntityEvent);
+                if (player.isSpectator()) playerInteractEntityEvent.cancel();
+                playerInteractEntityEvent.call();
                 if (playerInteractEntityEvent.isCancelled()) {
                     return;
                 }
@@ -547,9 +547,9 @@ public class InventoryTransactionProcessor extends DataPacketProcessor<Inventory
                         knockBack,
                         item.applyEnchantments() ? enchantments : null);
                 entityDamageByEntityEvent.setBreakShield(item.canBreakShield());
-                if (player.isSpectator()) entityDamageByEntityEvent.setCancelled();
+                if (player.isSpectator()) entityDamageByEntityEvent.cancel();
                 if ((target instanceof Player) && !player.level.getGameRules().getBoolean(GameRule.PVP)) {
-                    entityDamageByEntityEvent.setCancelled();
+                    entityDamageByEntityEvent.cancel();
                 }
 
                 // 保存攻击的目标在lastAttackEntity
@@ -712,7 +712,7 @@ public class InventoryTransactionProcessor extends DataPacketProcessor<Inventory
                 }
                 PlayerInteractEvent interactEvent = new PlayerInteractEvent(
                         player, item, directionVector, face, PlayerInteractEvent.Action.RIGHT_CLICK_AIR);
-                player.getServer().getPluginManager().callEvent(interactEvent);
+                interactEvent.call();
                 if (interactEvent.isCancelled()) {
                     player.getInventory().sendHeldItem(player);
                     return;

--- a/src/main/java/cn/nukkit/network/process/processor/LecternUpdateProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/LecternUpdateProcessor.java
@@ -28,7 +28,7 @@ public class LecternUpdateProcessor extends DataPacketProcessor<LecternUpdatePac
             if (blockEntityLectern instanceof BlockEntityLectern lectern) {
                 LecternPageChangeEvent lecternPageChangeEvent =
                         new LecternPageChangeEvent(playerHandle.player, lectern, pk.page);
-                playerHandle.player.getServer().getPluginManager().callEvent(lecternPageChangeEvent);
+                lecternPageChangeEvent.call();
                 if (!lecternPageChangeEvent.isCancelled()) {
                     lectern.setRawPage(lecternPageChangeEvent.getNewRawPage());
                     lectern.spawnToAll();

--- a/src/main/java/cn/nukkit/network/process/processor/LoginProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/LoginProcessor.java
@@ -112,9 +112,9 @@ public class LoginProcessor extends DataPacketProcessor<LoginPacket> {
             playerHandle.player.setSkin(skin);
         }
 
-        PlayerPreLoginEvent playerPreLoginEvent;
-        server.getPluginManager()
-                .callEvent(playerPreLoginEvent = new PlayerPreLoginEvent(playerHandle.player, "Plugin reason"));
+        PlayerPreLoginEvent playerPreLoginEvent = new PlayerPreLoginEvent(playerHandle.player, "Plugin reason");
+        playerPreLoginEvent.call();
+
         if (playerPreLoginEvent.isCancelled()) {
             playerHandle.player.close("", playerPreLoginEvent.getKickMessage());
             return;
@@ -132,7 +132,7 @@ public class LoginProcessor extends DataPacketProcessor<LoginPacket> {
                         playerHandle.player.getSkin(),
                         playerHandle.player.getRawAddress(),
                         playerHandle.player.getRawPort());
-                server.getPluginManager().callEvent(event);
+                event.call();
             }
 
             @Override

--- a/src/main/java/cn/nukkit/network/process/processor/MapInfoRequestProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/MapInfoRequestProcessor.java
@@ -54,8 +54,8 @@ public class MapInfoRequestProcessor extends DataPacketProcessor<MapInfoRequestP
         }
 
         if (mapItem != null) {
-            PlayerMapInfoRequestEvent event;
-            player.getServer().getPluginManager().callEvent(event = new PlayerMapInfoRequestEvent(player, mapItem));
+            PlayerMapInfoRequestEvent event = new PlayerMapInfoRequestEvent(player, mapItem);
+            event.call();
 
             if (!event.isCancelled()) {
                 ItemMap map = (ItemMap) mapItem;

--- a/src/main/java/cn/nukkit/network/process/processor/ModalFormResponseProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/ModalFormResponseProcessor.java
@@ -28,7 +28,7 @@ public class ModalFormResponseProcessor extends DataPacketProcessor<ModalFormRes
             }
 
             PlayerFormRespondedEvent event = new PlayerFormRespondedEvent(player, pk.formId, window);
-            player.getServer().getPluginManager().callEvent(event);
+            event.call();
         } else if (playerHandle.getServerSettings().containsKey(pk.formId)) {
             FormWindow window = playerHandle.getServerSettings().get(pk.formId);
             window.setResponse(pk.data.trim());
@@ -38,7 +38,7 @@ public class ModalFormResponseProcessor extends DataPacketProcessor<ModalFormRes
             }
 
             PlayerSettingsRespondedEvent event = new PlayerSettingsRespondedEvent(player, pk.formId, window);
-            player.getServer().getPluginManager().callEvent(event);
+            event.call();
 
             // Set back new settings if not been cancelled
             if (!event.isCancelled() && window instanceof FormWindowCustom formWindowCustom)

--- a/src/main/java/cn/nukkit/network/process/processor/MoveEntityAbsoluteProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/MoveEntityAbsoluteProcessor.java
@@ -36,7 +36,7 @@ public class MoveEntityAbsoluteProcessor extends DataPacketProcessor<MoveEntityA
         movedEntity.setPositionAndRotation(player.temporalVector, pk.headYaw, 0);
         Location to = movedEntity.getLocation();
         if (!from.equals(to)) {
-            player.getServer().getPluginManager().callEvent(new VehicleMoveEvent(player, from, to));
+            new VehicleMoveEvent(player, from, to).call();
         }
     }
 

--- a/src/main/java/cn/nukkit/network/process/processor/NPCRequestProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/NPCRequestProcessor.java
@@ -28,7 +28,7 @@ public class NPCRequestProcessor extends DataPacketProcessor<NPCRequestPacket> {
             }
 
             PlayerDialogRespondedEvent event = new PlayerDialogRespondedEvent(player, dialog, response);
-            player.getServer().getPluginManager().callEvent(event);
+            event.call();
             return;
         }
         if (playerHandle.getDialogWindows().getIfPresent(pk.getSceneName()) != null) {
@@ -47,7 +47,7 @@ public class NPCRequestProcessor extends DataPacketProcessor<NPCRequestPacket> {
             }
 
             PlayerDialogRespondedEvent event = new PlayerDialogRespondedEvent(player, dialog, response);
-            player.getServer().getPluginManager().callEvent(event);
+            event.call();
 
             // close dialog after clicked button (otherwise the client will not be able to close the window)
             if (response.getClickedButton() != null

--- a/src/main/java/cn/nukkit/network/process/processor/PlayerActionProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/PlayerActionProcessor.java
@@ -54,11 +54,11 @@ public class PlayerActionProcessor extends DataPacketProcessor<PlayerActionPacke
                 break;
             case PlayerActionPacket.ACTION_JUMP:
                 PlayerJumpEvent playerJumpEvent = new PlayerJumpEvent(player);
-                player.getServer().getPluginManager().callEvent(playerJumpEvent);
+                playerJumpEvent.call();
                 return;
             case PlayerActionPacket.ACTION_START_SPRINT:
                 PlayerToggleSprintEvent playerToggleSprintEvent = new PlayerToggleSprintEvent(player, true);
-                player.getServer().getPluginManager().callEvent(playerToggleSprintEvent);
+                playerToggleSprintEvent.call();
                 if (playerToggleSprintEvent.isCancelled()) {
                     player.sendData(player);
                 } else {
@@ -67,7 +67,7 @@ public class PlayerActionProcessor extends DataPacketProcessor<PlayerActionPacke
                 return;
             case PlayerActionPacket.ACTION_STOP_SPRINT:
                 playerToggleSprintEvent = new PlayerToggleSprintEvent(player, false);
-                player.getServer().getPluginManager().callEvent(playerToggleSprintEvent);
+                playerToggleSprintEvent.call();
                 if (playerToggleSprintEvent.isCancelled()) {
                     player.sendData(player);
                 } else {
@@ -76,7 +76,7 @@ public class PlayerActionProcessor extends DataPacketProcessor<PlayerActionPacke
                 return;
             case PlayerActionPacket.ACTION_START_SNEAK:
                 PlayerToggleSneakEvent playerToggleSneakEvent = new PlayerToggleSneakEvent(player, true);
-                player.getServer().getPluginManager().callEvent(playerToggleSneakEvent);
+                playerToggleSneakEvent.call();
                 if (playerToggleSneakEvent.isCancelled()) {
                     player.sendData(player);
                 } else {
@@ -85,7 +85,7 @@ public class PlayerActionProcessor extends DataPacketProcessor<PlayerActionPacke
                 return;
             case PlayerActionPacket.ACTION_STOP_SNEAK:
                 playerToggleSneakEvent = new PlayerToggleSneakEvent(player, false);
-                player.getServer().getPluginManager().callEvent(playerToggleSneakEvent);
+                playerToggleSneakEvent.call();
                 if (playerToggleSneakEvent.isCancelled()) {
                     player.sendData(player);
                 } else {
@@ -101,7 +101,7 @@ public class PlayerActionProcessor extends DataPacketProcessor<PlayerActionPacke
                 break; // TODO
             case PlayerActionPacket.ACTION_START_GLIDE:
                 PlayerToggleGlideEvent playerToggleGlideEvent = new PlayerToggleGlideEvent(player, true);
-                player.getServer().getPluginManager().callEvent(playerToggleGlideEvent);
+                playerToggleGlideEvent.call();
                 if (playerToggleGlideEvent.isCancelled()) {
                     player.sendData(player);
                 } else {
@@ -110,7 +110,7 @@ public class PlayerActionProcessor extends DataPacketProcessor<PlayerActionPacke
                 return;
             case PlayerActionPacket.ACTION_STOP_GLIDE:
                 playerToggleGlideEvent = new PlayerToggleGlideEvent(player, false);
-                player.getServer().getPluginManager().callEvent(playerToggleGlideEvent);
+                playerToggleGlideEvent.call();
                 if (playerToggleGlideEvent.isCancelled()) {
                     player.sendData(player);
                 } else {
@@ -121,20 +121,20 @@ public class PlayerActionProcessor extends DataPacketProcessor<PlayerActionPacke
                 playerHandle.onBlockBreakContinue(pos, face);
                 break;
             case PlayerActionPacket.ACTION_START_SWIMMING:
-                PlayerToggleSwimEvent ptse = new PlayerToggleSwimEvent(player, true);
-                player.getServer().getPluginManager().callEvent(ptse);
+                PlayerToggleSwimEvent playerToggleSwimEvent = new PlayerToggleSwimEvent(player, true);
+                playerToggleSwimEvent.call();
 
-                if (ptse.isCancelled()) {
+                if (playerToggleSwimEvent.isCancelled()) {
                     player.sendData(player);
                 } else {
                     player.setSwimming(true);
                 }
                 break;
             case PlayerActionPacket.ACTION_STOP_SWIMMING:
-                ptse = new PlayerToggleSwimEvent(player, false);
-                player.getServer().getPluginManager().callEvent(ptse);
+                playerToggleSwimEvent = new PlayerToggleSwimEvent(player, false);
+                playerToggleSwimEvent.call();
 
-                if (ptse.isCancelled()) {
+                if (playerToggleSwimEvent.isCancelled()) {
                     player.sendData(player);
                 } else {
                     player.setSwimming(false);
@@ -160,7 +160,7 @@ public class PlayerActionProcessor extends DataPacketProcessor<PlayerActionPacke
                 }
 
                 PlayerToggleSpinAttackEvent playerToggleSpinAttackEvent = new PlayerToggleSpinAttackEvent(player, true);
-                player.getServer().getPluginManager().callEvent(playerToggleSpinAttackEvent);
+                playerToggleSpinAttackEvent.call();
 
                 if (playerToggleSpinAttackEvent.isCancelled()) {
                     player.sendPosition(player, player.yaw, player.pitch, MovePlayerPacket.MODE_RESET);
@@ -180,7 +180,7 @@ public class PlayerActionProcessor extends DataPacketProcessor<PlayerActionPacke
                 return;
             case PlayerActionPacket.ACTION_STOP_SPIN_ATTACK:
                 playerToggleSpinAttackEvent = new PlayerToggleSpinAttackEvent(player, false);
-                player.getServer().getPluginManager().callEvent(playerToggleSpinAttackEvent);
+                playerToggleSpinAttackEvent.call();
 
                 if (playerToggleSpinAttackEvent.isCancelled()) {
                     player.sendData(player);

--- a/src/main/java/cn/nukkit/network/process/processor/PlayerAuthInputProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/PlayerAuthInputProcessor.java
@@ -75,7 +75,7 @@ public class PlayerAuthInputProcessor extends DataPacketProcessor<PlayerAuthInpu
 
         if (pk.getInputData().contains(AuthInputAction.START_SPRINTING)) {
             PlayerToggleSprintEvent event = new PlayerToggleSprintEvent(player, true);
-            player.getServer().getPluginManager().callEvent(event);
+            event.call();
             if (event.isCancelled()) {
                 player.sendData(player);
             } else {
@@ -84,7 +84,7 @@ public class PlayerAuthInputProcessor extends DataPacketProcessor<PlayerAuthInpu
         }
         if (pk.getInputData().contains(AuthInputAction.STOP_SPRINTING)) {
             PlayerToggleSprintEvent event = new PlayerToggleSprintEvent(player, false);
-            player.getServer().getPluginManager().callEvent(event);
+            event.call();
             if (event.isCancelled()) {
                 player.sendData(player);
             } else {
@@ -93,7 +93,7 @@ public class PlayerAuthInputProcessor extends DataPacketProcessor<PlayerAuthInpu
         }
         if (pk.getInputData().contains(AuthInputAction.START_SNEAKING)) {
             PlayerToggleSneakEvent event = new PlayerToggleSneakEvent(player, true);
-            player.getServer().getPluginManager().callEvent(event);
+            event.call();
             if (event.isCancelled()) {
                 player.sendData(player);
             } else {
@@ -102,7 +102,7 @@ public class PlayerAuthInputProcessor extends DataPacketProcessor<PlayerAuthInpu
         }
         if (pk.getInputData().contains(AuthInputAction.STOP_SNEAKING)) {
             PlayerToggleSneakEvent event = new PlayerToggleSneakEvent(player, false);
-            player.getServer().getPluginManager().callEvent(event);
+            event.call();
             if (event.isCancelled()) {
                 player.sendData(player);
             } else {
@@ -110,40 +110,40 @@ public class PlayerAuthInputProcessor extends DataPacketProcessor<PlayerAuthInpu
             }
         }
         if (pk.getInputData().contains(AuthInputAction.START_JUMPING)) {
-            PlayerJumpEvent playerJumpEvent = new PlayerJumpEvent(player);
-            player.getServer().getPluginManager().callEvent(playerJumpEvent);
+            PlayerJumpEvent event = new PlayerJumpEvent(player);
+            event.call();
         }
         if (pk.getInputData().contains(AuthInputAction.START_SWIMMING)) {
-            var playerSwimmingEvent = new PlayerToggleSwimEvent(player, true);
-            player.getServer().getPluginManager().callEvent(playerSwimmingEvent);
-            if (playerSwimmingEvent.isCancelled()) {
+            PlayerToggleSwimEvent event = new PlayerToggleSwimEvent(player, true);
+            event.call();
+            if (event.isCancelled()) {
                 player.sendData(player);
             } else {
                 player.setSwimming(true);
             }
         }
         if (pk.getInputData().contains(AuthInputAction.STOP_SWIMMING)) {
-            var playerSwimmingEvent = new PlayerToggleSwimEvent(player, false);
-            player.getServer().getPluginManager().callEvent(playerSwimmingEvent);
-            if (playerSwimmingEvent.isCancelled()) {
+            PlayerToggleSwimEvent event = new PlayerToggleSwimEvent(player, false);
+            event.call();
+            if (event.isCancelled()) {
                 player.sendData(player);
             } else {
                 player.setSwimming(false);
             }
         }
         if (pk.getInputData().contains(AuthInputAction.START_GLIDING)) {
-            var playerToggleGlideEvent = new PlayerToggleGlideEvent(player, true);
-            player.getServer().getPluginManager().callEvent(playerToggleGlideEvent);
-            if (playerToggleGlideEvent.isCancelled()) {
+            PlayerToggleGlideEvent event = new PlayerToggleGlideEvent(player, true);
+            event.call();
+            if (event.isCancelled()) {
                 player.sendData(player);
             } else {
                 player.setGliding(true);
             }
         }
         if (pk.getInputData().contains(AuthInputAction.STOP_GLIDING)) {
-            var playerToggleGlideEvent = new PlayerToggleGlideEvent(player, false);
-            player.getServer().getPluginManager().callEvent(playerToggleGlideEvent);
-            if (playerToggleGlideEvent.isCancelled()) {
+            PlayerToggleGlideEvent event = new PlayerToggleGlideEvent(player, false);
+            event.call();
+            if (event.isCancelled()) {
                 player.sendData(player);
             } else {
                 player.setGliding(false);

--- a/src/main/java/cn/nukkit/network/process/processor/PlayerSkinProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/PlayerSkinProcessor.java
@@ -32,10 +32,10 @@ public class PlayerSkinProcessor extends DataPacketProcessor<PlayerSkinPacket> {
         var tooQuick = TimeUnit.SECONDS.toMillis(player.getServer().getPlayerSkinChangeCooldown())
                 > System.currentTimeMillis() - player.lastSkinChange;
         if (tooQuick) {
-            playerChangeSkinEvent.setCancelled(true);
+            playerChangeSkinEvent.cancel();
             log.warn("Player " + playerHandle.getUsername() + " change skin too quick!");
         }
-        player.getServer().getPluginManager().callEvent(playerChangeSkinEvent);
+        playerChangeSkinEvent.call();
         if (!playerChangeSkinEvent.isCancelled()) {
             player.lastSkinChange = System.currentTimeMillis();
             player.setSkin(skin);

--- a/src/main/java/cn/nukkit/network/process/processor/RequestAbilityProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/RequestAbilityProcessor.java
@@ -32,7 +32,7 @@ public class RequestAbilityProcessor extends DataPacketProcessor<RequestAbilityP
         }
 
         PlayerToggleFlightEvent playerToggleFlightEvent = new PlayerToggleFlightEvent(player, pk.boolValue);
-        player.getServer().getPluginManager().callEvent(playerToggleFlightEvent);
+        playerToggleFlightEvent.call();
         if (playerToggleFlightEvent.isCancelled()) {
             player.getAdventureSettings().update();
         } else {

--- a/src/main/java/cn/nukkit/network/process/processor/ServerSettingsRequestProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/ServerSettingsRequestProcessor.java
@@ -14,7 +14,7 @@ public class ServerSettingsRequestProcessor extends DataPacketProcessor<ServerSe
     public void handle(@NotNull PlayerHandle playerHandle, @NotNull ServerSettingsRequestPacket pk) {
         PlayerServerSettingsRequestEvent settingsRequestEvent = new PlayerServerSettingsRequestEvent(
                 playerHandle.player, new HashMap<>(playerHandle.getServerSettings()));
-        playerHandle.player.getServer().getPluginManager().callEvent(settingsRequestEvent);
+        settingsRequestEvent.call();
 
         if (!settingsRequestEvent.isCancelled()) {
             settingsRequestEvent.getSettings().forEach((id, window) -> {

--- a/src/main/java/cn/nukkit/network/process/processor/SetLocalPlayerAsInitializedProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/SetLocalPlayerAsInitializedProcessor.java
@@ -16,7 +16,7 @@ public class SetLocalPlayerAsInitializedProcessor extends DataPacketProcessor<Se
         playerHandle.player.locallyInitialized = true;
         playerHandle.onPlayerLocallyInitialized();
         PlayerLocallyInitializedEvent locallyInitializedEvent = new PlayerLocallyInitializedEvent(playerHandle.player);
-        playerHandle.player.getServer().getPluginManager().callEvent(locallyInitializedEvent);
+        locallyInitializedEvent.call();
     }
 
     @Override

--- a/src/main/java/cn/nukkit/network/rcon/RCON.java
+++ b/src/main/java/cn/nukkit/network/rcon/RCON.java
@@ -49,7 +49,7 @@ public class RCON {
         while ((command = serverThread.receive()) != null) {
             RemoteConsoleCommandSender sender = new RemoteConsoleCommandSender();
             RemoteServerCommandEvent event = new RemoteServerCommandEvent(sender, command.getCommand());
-            this.server.getPluginManager().callEvent(event);
+            event.call();
 
             if (!event.isCancelled()) {
                 this.server.executeCommand(sender, command.getCommand());

--- a/src/main/java/cn/nukkit/player/Player.java
+++ b/src/main/java/cn/nukkit/player/Player.java
@@ -591,7 +591,7 @@ public class Player extends EntityHuman
                 target,
                 face,
                 target.getId() == 0 ? Action.LEFT_CLICK_AIR : Action.LEFT_CLICK_BLOCK);
-        this.getServer().getPluginManager().callEvent(playerInteractEvent);
+        playerInteractEvent.call();
         if (playerInteractEvent.isCancelled()) {
             this.inventory.sendHeldItem(this);
             this.getLevel()
@@ -814,8 +814,8 @@ public class Player extends EntityHuman
 
                 iter.remove();
 
-                PlayerChunkRequestEvent ev = new PlayerChunkRequestEvent(this, chunkX, chunkZ);
-                this.server.getPluginManager().callEvent(ev);
+                PlayerChunkRequestEvent event = new PlayerChunkRequestEvent(this, chunkX, chunkZ);
+                event.call();
                 this.level.requestChunk(chunkX, chunkZ, this);
             }
         }
@@ -853,7 +853,7 @@ public class Player extends EntityHuman
                 new TranslationContainer(
                         TextFormat.YELLOW + "%multiplayer.player.joined", new String[] {this.getDisplayName()}));
 
-        this.server.getPluginManager().callEvent(playerJoinEvent);
+        playerJoinEvent.call();
 
         if (playerJoinEvent.getJoinMessage().toString().trim().length() > 0) {
             this.server.broadcastMessage(playerJoinEvent.getJoinMessage());
@@ -1079,10 +1079,10 @@ public class Player extends EntityHuman
             if (!inEndPortal) {
                 inEndPortal = true;
                 if (this.getRiding() == null && this.getPassengers().isEmpty()) {
-                    EntityPortalEnterEvent ev = new EntityPortalEnterEvent(this, PortalType.END);
-                    getServer().getPluginManager().callEvent(ev);
+                    EntityPortalEnterEvent event = new EntityPortalEnterEvent(this, PortalType.END);
+                    event.call();
 
-                    if (!ev.isCancelled()) {
+                    if (!event.isCancelled()) {
                         final Position newPos = EnumLevel.moveToTheEnd(this);
                         if (newPos != null) {
                             if (newPos.getLevel().getDimension() == Level.DIMENSION_THE_END) {
@@ -1105,7 +1105,7 @@ public class Player extends EntityHuman
                             } else {
                                 if (!this.hasSeenCredits && !this.showingCredits) {
                                     PlayerShowCreditsEvent playerShowCreditsEvent = new PlayerShowCreditsEvent(this);
-                                    this.getServer().getPluginManager().callEvent(playerShowCreditsEvent);
+                                    playerShowCreditsEvent.call();
                                     if (!playerShowCreditsEvent.isCancelled()) {
                                         this.showCredits();
                                     }
@@ -1190,7 +1190,7 @@ public class Player extends EntityHuman
             // 这里放宽了判断，否则对角穿过脚手架会判断非法移动。
             if (diff > 1.2) {
                 PlayerInvalidMoveEvent event = new PlayerInvalidMoveEvent(this, true);
-                this.getServer().getPluginManager().callEvent(event);
+                event.call();
                 if (!event.isCancelled() && (invalidMotion = event.isRevert())) {
                     log.warn(this.getServer().getLanguage().tr("nukkit.player.invalidMove", this.getName()));
                 }
@@ -1230,17 +1230,17 @@ public class Player extends EntityHuman
                 this.blocksAround = null;
                 this.collisionBlocks = null;
             }
-            PlayerMoveEvent ev = new PlayerMoveEvent(this, last, now);
-            this.server.getPluginManager().callEvent(ev);
+            PlayerMoveEvent event = new PlayerMoveEvent(this, last, now);
+            event.call();
 
-            if (!(invalidMotion = ev.isCancelled())) { // Yes, this is intended
-                if (!now.equals(ev.getTo()) && this.riding == null) { // If plugins modify the destination
+            if (!(invalidMotion = event.isCancelled())) { // Yes, this is intended
+                if (!now.equals(event.getTo()) && this.riding == null) { // If plugins modify the destination
                     if (this.getGamemode() != Player.SPECTATOR)
                         this.level
                                 .getVibrationManager()
                                 .callVibrationEvent(
-                                        new VibrationEvent(this, ev.getTo().clone(), VibrationType.TELEPORT));
-                    this.teleport(ev.getTo(), null);
+                                        new VibrationEvent(this, event.getTo().clone(), VibrationType.TELEPORT));
+                    this.teleport(event.getTo(), null);
                 } else {
                     if (this.getGamemode() != Player.SPECTATOR
                             && (last.x != now.x || last.y != now.y || last.z != now.z)) {
@@ -1359,9 +1359,9 @@ public class Player extends EntityHuman
                                 continue;
                             }
                         }
-                        WaterFrostEvent ev = new WaterFrostEvent(block, this);
-                        server.getPluginManager().callEvent(ev);
-                        if (!ev.isCancelled()) {
+                        WaterFrostEvent event = new WaterFrostEvent(block, this);
+                        event.call();
+                        if (!event.isCancelled()) {
                             level.setBlock(block, layer, Block.get(Block.ICE_FROSTED), true, false);
                             level.scheduleUpdate(
                                     level.getBlock(block, layer),
@@ -1593,10 +1593,11 @@ public class Player extends EntityHuman
      * 异步登录任务成功完成后执行
      */
     protected void completeLoginSequence() {
-        PlayerLoginEvent ev;
-        this.server.getPluginManager().callEvent(ev = new PlayerLoginEvent(this, "Plugin reason"));
-        if (ev.isCancelled()) {
-            this.close(this.getLeaveMessage(), ev.getKickMessage());
+        PlayerLoginEvent event = new PlayerLoginEvent(this, "Plugin reason");
+        event.call();
+
+        if (event.isCancelled()) {
+            this.close(this.getLeaveMessage(), event.getKickMessage());
             return;
         }
 
@@ -1748,7 +1749,7 @@ public class Player extends EntityHuman
             pos = new Location(this.x, this.y, this.z, this.yaw, this.pitch, this.level);
         }
         PlayerRespawnEvent respawnEvent = new PlayerRespawnEvent(this, pos, true);
-        this.server.getPluginManager().callEvent(respawnEvent);
+        respawnEvent.call();
         Position fromEvent = respawnEvent.getRespawnPosition();
         if (fromEvent instanceof Location) {
             pos = fromEvent.getLocation();
@@ -1830,7 +1831,7 @@ public class Player extends EntityHuman
                     this.getServer().getDefaultLevel().getSafeSpawn());
         }
 
-        this.server.getPluginManager().callEvent(playerRespawnEvent);
+        playerRespawnEvent.call();
         Position respawnPos = playerRespawnEvent.getRespawnPosition();
 
         this.sendExperience();
@@ -2910,9 +2911,9 @@ public class Player extends EntityHuman
         if (!this.connected) {
             return false;
         }
-        DataPacketSendEvent ev = new DataPacketSendEvent(this, packet);
-        this.server.getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        DataPacketSendEvent event = new DataPacketSendEvent(this, packet);
+        event.call();
+        if (event.isCancelled()) {
             return false;
         }
         if (log.isTraceEnabled() && !server.isIgnoredPacket(packet.getClass())) {
@@ -3000,9 +3001,10 @@ public class Player extends EntityHuman
             }
         }
 
-        PlayerBedEnterEvent ev;
-        this.server.getPluginManager().callEvent(ev = new PlayerBedEnterEvent(this, this.level.getBlock(pos)));
-        if (ev.isCancelled()) {
+        PlayerBedEnterEvent event = new PlayerBedEnterEvent(this, this.level.getBlock(pos));
+        event.call();
+
+        if (event.isCancelled()) {
             return false;
         }
 
@@ -3022,7 +3024,8 @@ public class Player extends EntityHuman
 
     public void stopSleep() {
         if (this.sleeping != null) {
-            this.server.getPluginManager().callEvent(new PlayerBedLeaveEvent(this, this.level.getBlock(this.sleeping)));
+            PlayerBedLeaveEvent event = new PlayerBedLeaveEvent(this, this.level.getBlock(this.sleeping));
+            event.call();
 
             this.sleeping = null;
             this.setDataProperty(new IntPositionEntityData(DATA_PLAYER_BED_POSITION, 0, 0, 0));
@@ -3097,10 +3100,10 @@ public class Player extends EntityHuman
                     });
         }
 
-        PlayerGameModeChangeEvent ev;
-        this.server.getPluginManager().callEvent(ev = new PlayerGameModeChangeEvent(this, gamemode, newSettings));
+        PlayerGameModeChangeEvent event = new PlayerGameModeChangeEvent(this, gamemode, newSettings);
+        event.call();
 
-        if (ev.isCancelled()) {
+        if (event.isCancelled()) {
             return false;
         }
 
@@ -3115,7 +3118,7 @@ public class Player extends EntityHuman
 
         this.namedTag.putInt("playerGameType", this.gamemode);
 
-        this.setAdventureSettings(ev.getNewAdventureSettings());
+        this.setAdventureSettings(event.getNewAdventureSettings());
 
         if (!serverSide) {
             var pk = new UpdatePlayerGameTypePacket();
@@ -3620,9 +3623,9 @@ public class Player extends EntityHuman
             return;
         }
 
-        DataPacketReceiveEvent ev = new DataPacketReceiveEvent(this, packet);
-        this.server.getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        DataPacketReceiveEvent event = new DataPacketReceiveEvent(this, packet);
+        event.call();
+        if (event.isCancelled()) {
             return;
         }
         if (packet.packetId() == ProtocolInfo.toNewProtocolID(ProtocolInfo.BATCH_PACKET)) {
@@ -3662,7 +3665,7 @@ public class Player extends EntityHuman
         for (String msg : message.split("\n")) {
             if (!msg.trim().isEmpty() && msg.length() <= 512 && this.messageCounter-- > 0) {
                 PlayerChatEvent chatEvent = new PlayerChatEvent(this, msg);
-                this.server.getPluginManager().callEvent(chatEvent);
+                chatEvent.call();
                 if (!chatEvent.isCancelled()) {
                     this.server.broadcastMessage(
                             this.getServer().getLanguage().tr(chatEvent.getFormat(), new String[] {
@@ -3735,9 +3738,10 @@ public class Player extends EntityHuman
      * @return boolean
      */
     public boolean kick(PlayerKickEvent.Reason reason, String reasonString, boolean isAdmin) {
-        PlayerKickEvent ev;
-        this.server.getPluginManager().callEvent(ev = new PlayerKickEvent(this, reason, this.getLeaveMessage()));
-        if (!ev.isCancelled()) {
+        PlayerKickEvent event = new PlayerKickEvent(this, reason, this.getLeaveMessage());
+        event.call();
+
+        if (!event.isCancelled()) {
             String message;
             if (isAdmin) {
                 if (!this.isBanned()) {
@@ -3753,7 +3757,7 @@ public class Player extends EntityHuman
                 }
             }
 
-            this.close(ev.getQuitMessage(), message);
+            this.close(event.getQuitMessage(), message);
 
             return true;
         }
@@ -4185,9 +4189,10 @@ public class Player extends EntityHuman
             }
 
             this.connected = false;
-            PlayerQuitEvent ev = null;
+            PlayerQuitEvent event = null;
             if (this.getName() != null && this.getName().length() > 0) {
-                this.server.getPluginManager().callEvent(ev = new PlayerQuitEvent(this, message, true, reason));
+                event = new PlayerQuitEvent(this, message, true, reason);
+                event.call();
                 if (this.fishing != null) {
                     this.stopFishing(false);
                 }
@@ -4197,7 +4202,7 @@ public class Player extends EntityHuman
             this.removeAllWindows(false);
             resetCraftingGridType();
 
-            if (ev != null && this.loggedIn && ev.getAutoSave()) {
+            if (event != null && this.loggedIn && event.getAutoSave()) {
                 this.save();
             }
 
@@ -4235,11 +4240,11 @@ public class Player extends EntityHuman
 
             this.loggedIn = false;
 
-            if (ev != null
+            if (event != null
                     && !Objects.equals(this.username, "")
                     && this.spawned
-                    && !Objects.equals(ev.getQuitMessage().toString(), "")) {
-                this.server.broadcastMessage(ev.getQuitMessage());
+                    && !Objects.equals(event.getQuitMessage().toString(), "")) {
+                this.server.broadcastMessage(event.getQuitMessage());
             }
 
             this.server.getPluginManager().unsubscribeFromPermission(Server.BROADCAST_CHANNEL_USERS, this);
@@ -4530,17 +4535,17 @@ public class Player extends EntityHuman
             }
         }
 
-        PlayerDeathEvent ev = new PlayerDeathEvent(
+        PlayerDeathEvent event = new PlayerDeathEvent(
                 this,
                 this.getDrops(),
                 new TranslationContainer(message, params.toArray(EmptyArrays.EMPTY_STRINGS)),
                 this.expLevel);
-        ev.setKeepExperience(this.level.gameRules.getBoolean(GameRule.KEEP_INVENTORY));
-        ev.setKeepInventory(ev.getKeepExperience());
+        event.setKeepExperience(this.level.gameRules.getBoolean(GameRule.KEEP_INVENTORY));
+        event.setKeepInventory(event.getKeepExperience());
 
-        this.server.getPluginManager().callEvent(ev);
+        event.call();
 
-        if (!ev.isCancelled()) {
+        if (!event.isCancelled()) {
             if (this.fishing != null) {
                 this.stopFishing(false);
             }
@@ -4548,8 +4553,8 @@ public class Player extends EntityHuman
             this.health = 0;
             this.extinguish();
             this.scheduleUpdate();
-            if (!ev.getKeepInventory() && this.level.getGameRules().getBoolean(GameRule.DO_ENTITY_DROPS)) {
-                for (Item item : ev.getDrops()) {
+            if (!event.getKeepInventory() && this.level.getGameRules().getBoolean(GameRule.DO_ENTITY_DROPS)) {
+                for (Item item : event.getDrops()) {
                     if (!item.hasEnchantment(Enchantment.ID_VANISHING_CURSE) && item.applyEnchantments()) {
                         this.level.dropItem(this, item, null, true, 40);
                     }
@@ -4571,9 +4576,9 @@ public class Player extends EntityHuman
                 }
             }
 
-            if (!ev.getKeepExperience() && this.level.getGameRules().getBoolean(GameRule.DO_ENTITY_DROPS)) {
+            if (!event.getKeepExperience() && this.level.getGameRules().getBoolean(GameRule.DO_ENTITY_DROPS)) {
                 if (this.isSurvival() || this.isAdventure()) {
-                    int exp = ev.getExperience() * 7;
+                    int exp = event.getExperience() * 7;
                     if (exp > 100) exp = 100;
                     this.getLevel().dropExpOrb(this, exp);
                 }
@@ -4583,11 +4588,11 @@ public class Player extends EntityHuman
             this.timeSinceRest = 0;
 
             DeathInfoPacket deathInfo = new DeathInfoPacket();
-            deathInfo.translation = ev.getTranslationDeathMessage();
+            deathInfo.translation = event.getTranslationDeathMessage();
             this.dataPacket(deathInfo);
 
-            if (showMessages && !ev.getDeathMessage().toString().isEmpty()) {
-                this.server.broadcast(ev.getDeathMessage(), Server.BROADCAST_CHANNEL_USERS);
+            if (showMessages && !event.getDeathMessage().toString().isEmpty()) {
+                this.server.broadcast(event.getDeathMessage(), Server.BROADCAST_CHANNEL_USERS);
             }
 
             RespawnPacket pk = new RespawnPacket();
@@ -4737,9 +4742,9 @@ public class Player extends EntityHuman
     // todo something on performance, lots of exp orbs then lots of packets, could crash client
     @PowerNukkitOnly
     public void setExperience(int exp, int level, boolean playLevelUpSound) {
-        var expEvent =
+        PlayerExperienceChangeEvent expEvent =
                 new PlayerExperienceChangeEvent(this, this.getExperience(), this.getExperienceLevel(), exp, level);
-        this.server.getPluginManager().callEvent(expEvent);
+        expEvent.call();
         if (expEvent.isCancelled()) {
             return;
         }
@@ -5035,7 +5040,7 @@ public class Player extends EntityHuman
         // event
         if (cause != null) {
             PlayerTeleportEvent event = new PlayerTeleportEvent(this, from, to, cause);
-            this.server.getPluginManager().callEvent(event);
+            event.call();
             if (event.isCancelled()) return false;
             to = event.getTo();
         }
@@ -5743,16 +5748,16 @@ public class Player extends EntityHuman
                     }
                 }
 
-                InventoryPickupArrowEvent ev = new InventoryPickupArrowEvent(inventory, (EntityArrow) entity);
+                InventoryPickupArrowEvent event = new InventoryPickupArrowEvent(inventory, (EntityArrow) entity);
 
                 int pickupMode = ((EntityArrow) entity).getPickupMode();
                 if (pickupMode == EntityProjectile.PICKUP_NONE
                         || (pickupMode == EntityProjectile.PICKUP_CREATIVE && !this.isCreative())) {
-                    ev.setCancelled();
+                    event.cancel();
                 }
 
-                this.server.getPluginManager().callEvent(ev);
-                if (ev.isCancelled()) {
+                event.call();
+                if (event.isCancelled()) {
                     return false;
                 }
 
@@ -5788,17 +5793,17 @@ public class Player extends EntityHuman
                     return false;
                 }
 
-                InventoryPickupTridentEvent ev =
+                InventoryPickupTridentEvent event =
                         new InventoryPickupTridentEvent(this.inventory, (EntityThrownTrident) entity);
 
                 int pickupMode = ((EntityThrownTrident) entity).getPickupMode();
                 if (pickupMode == EntityProjectile.PICKUP_NONE
                         || (pickupMode == EntityProjectile.PICKUP_CREATIVE && !this.isCreative())) {
-                    ev.setCancelled();
+                    event.cancel();
                 }
 
-                this.server.getPluginManager().callEvent(ev);
-                if (ev.isCancelled()) {
+                event.call();
+                if (event.isCancelled()) {
                     return false;
                 }
 
@@ -5829,11 +5834,9 @@ public class Player extends EntityHuman
                             return false;
                         }
 
-                        InventoryPickupItemEvent ev;
-                        this.server
-                                .getPluginManager()
-                                .callEvent(ev = new InventoryPickupItemEvent(inventory, (EntityItem) entity));
-                        if (ev.isCancelled()) {
+                        InventoryPickupItemEvent event = new InventoryPickupItemEvent(inventory, (EntityItem) entity);
+                        event.call();
+                        if (event.isCancelled()) {
                             return false;
                         }
 
@@ -5959,9 +5962,9 @@ public class Player extends EntityHuman
                 -Math.sin(Math.toRadians(yaw)) * Math.cos(Math.toRadians(pitch)) * f * f,
                 -Math.sin(Math.toRadians(pitch)) * f * f,
                 Math.cos(Math.toRadians(yaw)) * Math.cos(Math.toRadians(pitch)) * f * f));
-        ProjectileLaunchEvent ev = new ProjectileLaunchEvent(fishingHook, this);
-        this.getServer().getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        ProjectileLaunchEvent event = new ProjectileLaunchEvent(fishingHook, this);
+        event.call();
+        if (event.isCancelled()) {
             fishingHook.close();
         } else {
             this.fishing = fishingHook;
@@ -6141,9 +6144,9 @@ public class Player extends EntityHuman
         if (!this.connected) {
             return false;
         }
-        DataPacketSendEvent ev = new DataPacketSendEvent(this, packet);
-        this.server.getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        DataPacketSendEvent event = new DataPacketSendEvent(this, packet);
+        event.call();
+        if (event.isCancelled()) {
             return false;
         }
         if (log.isTraceEnabled() && !server.isIgnoredPacket(packet.getClass())) {
@@ -6159,9 +6162,9 @@ public class Player extends EntityHuman
         if (!this.connected) {
             return false;
         }
-        DataPacketSendEvent ev = new DataPacketSendEvent(this, packet);
-        this.server.getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        DataPacketSendEvent event = new DataPacketSendEvent(this, packet);
+        event.call();
+        if (event.isCancelled()) {
             return false;
         }
         if (log.isTraceEnabled() && !server.isIgnoredPacket(packet.getClass())) {

--- a/src/main/java/cn/nukkit/player/PlayerFood.java
+++ b/src/main/java/cn/nukkit/player/PlayerFood.java
@@ -61,14 +61,14 @@ public class PlayerFood {
             }
         }
 
-        PlayerFoodLevelChangeEvent ev = new PlayerFoodLevelChangeEvent(this.getPlayer(), foodLevel, saturationLevel);
-        this.getPlayer().getServer().getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        PlayerFoodLevelChangeEvent event = new PlayerFoodLevelChangeEvent(this.getPlayer(), foodLevel, saturationLevel);
+        event.call();
+        if (event.isCancelled()) {
             this.sendFoodLevel(this.getLevel());
             return;
         }
-        int foodLevel0 = ev.getFoodLevel();
-        float fsl = ev.getFoodSaturationLevel();
+        int foodLevel0 = event.getFoodLevel();
+        float fsl = event.getFoodSaturationLevel();
         this.foodLevel = foodLevel;
         if (fsl != -1) {
             if (fsl > foodLevel) fsl = foodLevel;
@@ -85,12 +85,12 @@ public class PlayerFood {
     public void setFoodSaturationLevel(float fsl) {
         if (fsl > this.getLevel()) fsl = this.getLevel();
         if (fsl < 0) fsl = 0;
-        PlayerFoodLevelChangeEvent ev = new PlayerFoodLevelChangeEvent(this.getPlayer(), this.getLevel(), fsl);
-        this.getPlayer().getServer().getPluginManager().callEvent(ev);
-        if (ev.isCancelled()) {
+        PlayerFoodLevelChangeEvent event = new PlayerFoodLevelChangeEvent(this.getPlayer(), this.getLevel(), fsl);
+        event.call();
+        if (event.isCancelled()) {
             return;
         }
-        fsl = ev.getFoodSaturationLevel();
+        fsl = event.getFoodSaturationLevel();
         this.foodSaturationLevel = fsl;
     }
 

--- a/src/main/java/cn/nukkit/player/PlayerManager.java
+++ b/src/main/java/cn/nukkit/player/PlayerManager.java
@@ -298,7 +298,7 @@ public class PlayerManager {
 
         PlayerDataSerializeEvent event = new PlayerDataSerializeEvent(name, playerDataSerializer);
         if (runEvent) {
-            server.getPluginManager().callEvent(event);
+            event.call();
         }
 
         Optional<InputStream> dataStream = Optional.empty();
@@ -372,7 +372,7 @@ public class PlayerManager {
         if (server.shouldSavePlayerData()) {
             PlayerDataSerializeEvent event = new PlayerDataSerializeEvent(nameLower, playerDataSerializer);
             if (runEvent) {
-                server.getPluginManager().callEvent(event);
+                event.call();
             }
 
             server.getScheduler()

--- a/src/main/java/cn/nukkit/plugin/JavaPluginLoader.java
+++ b/src/main/java/cn/nukkit/plugin/JavaPluginLoader.java
@@ -134,7 +134,7 @@ public class JavaPluginLoader implements PluginLoader {
 
             ((PluginBase) plugin).setEnabled(true);
 
-            this.server.getPluginManager().callEvent(new PluginEnableEvent(plugin));
+            new PluginEnableEvent(plugin).call();
         }
     }
 
@@ -154,8 +154,7 @@ public class JavaPluginLoader implements PluginLoader {
                     .tr("nukkit.plugin.disable", plugin.getDescription().getFullName()));
 
             this.server.getServiceManager().cancel(plugin);
-
-            this.server.getPluginManager().callEvent(new PluginDisableEvent(plugin));
+            new PluginDisableEvent(plugin).call();
 
             ((PluginBase) plugin).setEnabled(false);
         }

--- a/src/main/java/cn/nukkit/potion/Effect.java
+++ b/src/main/java/cn/nukkit/potion/Effect.java
@@ -1,6 +1,5 @@
 package cn.nukkit.potion;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.DeprecationDetails;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.Since;
@@ -309,7 +308,7 @@ public class Effect implements Cloneable {
         Effect oldEffect = entity.getEffect(getId());
 
         EntityEffectUpdateEvent event = new EntityEffectUpdateEvent(entity, oldEffect, this);
-        Server.getInstance().getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) {
             return;
         }
@@ -373,7 +372,7 @@ public class Effect implements Cloneable {
 
     public void remove(Entity entity) {
         EntityEffectRemoveEvent event = new EntityEffectRemoveEvent(entity, this);
-        Server.getInstance().getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) {
             return;
         }

--- a/src/main/java/cn/nukkit/potion/Potion.java
+++ b/src/main/java/cn/nukkit/potion/Potion.java
@@ -221,8 +221,8 @@ public class Potion implements Cloneable {
         }
 
         PotionApplyEvent event = new PotionApplyEvent(this, applyEffect, entity);
+        event.call();
 
-        entity.getServer().getPluginManager().callEvent(event);
         if (event.isCancelled()) {
             return;
         }

--- a/src/main/java/cn/nukkit/scoreboard/manager/ScoreboardManager.java
+++ b/src/main/java/cn/nukkit/scoreboard/manager/ScoreboardManager.java
@@ -1,6 +1,5 @@
 package cn.nukkit.scoreboard.manager;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.command.data.CommandEnum;
@@ -36,7 +35,7 @@ public class ScoreboardManager implements IScoreboardManager {
     @Override
     public boolean addScoreboard(IScoreboard scoreboard) {
         var event = new ScoreboardObjectiveChangeEvent(scoreboard, ScoreboardObjectiveChangeEvent.ActionType.ADD);
-        Server.getInstance().getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) {
             return false;
         }
@@ -55,7 +54,7 @@ public class ScoreboardManager implements IScoreboardManager {
         var removed = scoreboards.get(objectiveName);
         if (removed == null) return false;
         var event = new ScoreboardObjectiveChangeEvent(removed, ScoreboardObjectiveChangeEvent.ActionType.REMOVE);
-        Server.getInstance().getPluginManager().callEvent(event);
+        event.call();
         if (event.isCancelled()) {
             return false;
         }

--- a/src/main/java/cn/nukkit/scoreboard/scoreboard/Scoreboard.java
+++ b/src/main/java/cn/nukkit/scoreboard/scoreboard/Scoreboard.java
@@ -91,7 +91,7 @@ public class Scoreboard implements IScoreboard {
         if (shouldCallEvent()) {
             var event = new ScoreboardLineChangeEvent(
                     this, line, line.getScore(), line.getScore(), ScoreboardLineChangeEvent.ActionType.ADD_LINE);
-            Server.getInstance().getPluginManager().callEvent(event);
+            event.call();
             if (event.isCancelled()) return false;
             line = event.getLine();
         }
@@ -122,7 +122,7 @@ public class Scoreboard implements IScoreboard {
                     removed.getScore(),
                     removed.getScore(),
                     ScoreboardLineChangeEvent.ActionType.REMOVE_LINE);
-            Server.getInstance().getPluginManager().callEvent(event);
+            event.call();
             if (event.isCancelled()) return false;
         }
         this.lines.remove(scorer);
@@ -136,7 +136,7 @@ public class Scoreboard implements IScoreboard {
         if (shouldCallEvent()) {
             var event = new ScoreboardLineChangeEvent(
                     this, null, 0, 0, ScoreboardLineChangeEvent.ActionType.REMOVE_ALL_LINES);
-            Server.getInstance().getPluginManager().callEvent(event);
+            event.call();
             if (event.isCancelled()) return false;
         }
         if (send) {

--- a/src/main/java/cn/nukkit/scoreboard/scoreboard/ScoreboardLine.java
+++ b/src/main/java/cn/nukkit/scoreboard/scoreboard/ScoreboardLine.java
@@ -1,6 +1,5 @@
 package cn.nukkit.scoreboard.scoreboard;
 
-import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.event.scoreboard.ScoreboardLineChangeEvent;
@@ -35,7 +34,7 @@ public class ScoreboardLine implements IScoreboardLine {
         if (scoreboard.shouldCallEvent()) {
             var event = new ScoreboardLineChangeEvent(
                     scoreboard, this, score, this.score, ScoreboardLineChangeEvent.ActionType.SCORE_CHANGE);
-            Server.getInstance().getPluginManager().callEvent(event);
+            event.call();
             if (event.isCancelled()) {
                 return false;
             }

--- a/src/test/java/cn/nukkit/item/ItemTridentTest.java
+++ b/src/test/java/cn/nukkit/item/ItemTridentTest.java
@@ -73,11 +73,11 @@ class ItemTridentTest {
     void onReleaseCancelBow() {
         PluginManager pluginManager = Server.getInstance().getPluginManager();
         doAnswer(call -> {
-                    ((Event) call.getArgument(0)).setCancelled();
+                    ((Event) call.getArgument(0)).cancel();
                     return null;
                 })
-                .when(pluginManager)
-                .callEvent(any(EntityShootBowEvent.class));
+                .when(any(EntityShootBowEvent.class))
+                .call();
         assertTrue(item.onRelease(player, 20));
         Optional<EntityThrownTrident> optTrident = Arrays.stream(level.getEntities())
                 .filter(EntityThrownTrident.class::isInstance)
@@ -90,11 +90,11 @@ class ItemTridentTest {
     void onReleaseCancelProjectLaunch() {
         PluginManager pluginManager = Server.getInstance().getPluginManager();
         doAnswer(call -> {
-                    ((Event) call.getArgument(0)).setCancelled();
+                    ((Event) call.getArgument(0)).cancel();
                     return null;
                 })
-                .when(pluginManager)
-                .callEvent(any(ProjectileLaunchEvent.class));
+                .when(any(ProjectileLaunchEvent.class))
+                .call();
         assertTrue(item.onRelease(player, 20));
         Optional<EntityThrownTrident> optTrident = Arrays.stream(level.getEntities())
                 .filter(EntityThrownTrident.class::isInstance)


### PR DESCRIPTION
1. Now the event is called by the Event#call() method
2. Changed methods Event#setCancelled() and Event#setCancelled(boolean value) to cancel() and uncancel() as in PMMP.
3. Distributed HandlerList into HandlerList and HandlerListManager
4. Now the event does not require public static HandlerList getHandlers() method in the event class
5. Removed all HandlerList from event classes
6. Added protection against recursive event call
7. Some classes related to events moved from package plugin to event